### PR TITLE
Remove unneeded datetime convert

### DIFF
--- a/gui/slick/interfaces/default/comingEpisodes.tmpl
+++ b/gui/slick/interfaces/default/comingEpisodes.tmpl
@@ -359,10 +359,10 @@
                 #set $too_late_header = True
                 #elif $cur_ep_enddate >= $today and $cur_ep_airdate < $next_week.date():
                     #if $cur_ep_airdate == $today.date():
-						<br /><h2 class="day">$datetime.date.fromordinal($cur_ep_airdate.toordinal).strftime('%A').decode($sickbeard.SYS_ENCODING).capitalize() <span style="font-size: 14px; vertical-align: top;">[Today]</span></h2>
+						<br /><h2 class="day">$sbdatetime.sbdatetime.sbfdate($cur_ep_airdate, '%A').decode($sickbeard.SYS_ENCODING).capitalize() <span style="font-size: 14px; vertical-align: top;">[Today]</span></h2>
 					#set $today_header = True
                     #else:
-						<br /><h2 class="day">$datetime.date.fromordinal($cur_ep_airdate.toordinal).strftime('%A').decode($sickbeard.SYS_ENCODING).capitalize()</h2>
+						<br /><h2 class="day">$sbdatetime.sbdatetime.sbfdate($cur_ep_airdate, '%A').decode($sickbeard.SYS_ENCODING).capitalize()</h2>
                     #end if
                 #end if
             #end if
@@ -371,7 +371,7 @@
 
         #if $cur_ep_airdate == $today.date() and not $today_header:
 			<div class="comingepheader">
-			<br /><h2 class="day">$datetime.date.fromordinal($cur_ep_airdate.toordinal).strftime('%A').decode($sickbeard.SYS_ENCODING).capitalize() <span style="font-size: 14px; vertical-align: top;">[Today]</span></h2>
+			<br /><h2 class="day">$sbdatetime.sbdatetime.sbfdate($cur_ep_airdate, '%A').decode($sickbeard.SYS_ENCODING).capitalize() <span style="font-size: 14px; vertical-align: top;">[Today]</span></h2>
             #set $today_header = True
         #end if
         #if $runtime:
@@ -489,7 +489,7 @@
     #for $day in $dates
     #set $tbl_day += 1
 		<table class="sickbeardTable tablesorter calendarTable <%= 'cal-%s' % (('even', 'odd')[1 == tbl_day % 2]) %>" cellspacing="0" border="0" cellpadding="0">
-		<thead><tr><th>$day.strftime('%A').decode($sickbeard.SYS_ENCODING).capitalize()</th></tr></thead>
+		<thead><tr><th>$sbdatetime.sbdatetime.sbfdate($day, '%A').decode($sickbeard.SYS_ENCODING).capitalize()</th></tr></thead>
 		<tbody>
         #set $day_has_show = False
         #for $cur_result in $sql_results:
@@ -503,7 +503,7 @@
 
             #if $airday == $day:
                 #set $day_has_show = True
-                #set $airtime = $sbdatetime.sbdatetime.fromtimestamp($time.mktime($cur_result['localtime'].timetuple())).sbftime().decode($sickbeard.SYS_ENCODING)
+                #set $airtime = $sbdatetime.sbdatetime.sbftime($cur_result['localtime']).decode($sickbeard.SYS_ENCODING)
                 #if $sickbeard.TRIM_ZERO:
                 #set $airtime = re.sub(r'0(\d:\d\d)', r'\1', $airtime, 0, re.IGNORECASE | re.MULTILINE)
                 #end if


### PR DESCRIPTION
Prevent usage of function .fromtimestamp and .fromordinal that can throw exceptions on some platforms, since these functions are based on the platforms C library. These library's can have different valid date and time ranges, this can throw exceptions.

This could fix the: 

```
timestamp out of range for platform time_t
```

Bug some reported. Since now the 2 functions that produce this exception aren't used anymore.

Also the calls are more simple and have less format changes, so it saves cpu time too.
