### PR TITLE
Fix a handler when ShowData is not available in tvdb and tvrage APIs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 * Change suppress HTTPS verification InsecureRequestWarning as many sites use self-certified certificates
 * Fix API endpoint Episode.SetStatus to "Wanted"
 * Change airdateModifyStamp to handle hour that is "00:00"
+* Fix a handler when ShowData is not available in tvdb and tvrage APIs
 
 [develop changelog]
 

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -936,7 +936,7 @@ class Tvdb:
             # Item is integer, treat as show id
             if key not in self.shows:
                 self._getShowData(key, self.config['language'], True)
-            return self.shows[key]
+            return (None, self.shows[key])[key in self.show]
 
         key = str(key).lower()
         self.config['searchterm'] = key

--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -658,7 +658,7 @@ class TVRage:
             # Item is integer, treat as show id
             if key not in self.shows:
                 self._getShowData(key, True)
-            return self.shows[key]
+            return (None, self.shows[key])[key in self.show]
 
         key = key.lower()
         self.config['searchterm'] = key


### PR DESCRIPTION
"KeyError:<show_id>" Traceback is addressed.
