### PR TITLE
Fix a handler when EpisodeData is not available in tvdb and tvrage APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 * Fix API endpoint Episode.SetStatus to "Wanted"
 * Change airdateModifyStamp to handle hour that is "00:00"
 * Fix a handler when ShowData is not available in tvdb and tvrage APIs
+* Fix a handler when EpisodeData is not available in tvdb and tvrage APIs
 
 [develop changelog]
 

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -871,8 +871,10 @@ class Tvdb:
                 url = self.config['url_epInfo'] % (sid, language)
 
             epsEt = self._getetsrc(url, language=language)
+            if 'episode' not in epsEt:
+                return False
 
-            episodes =  epsEt["episode"]
+            episodes = epsEt['episode']
             if not isinstance(episodes, list):
                 episodes = [episodes]
 

--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -604,6 +604,8 @@ class TVRage:
 
             self.config['params_epInfo']['sid'] = sid
             epsEt = self._getetsrc(self.config['url_epInfo'], self.config['params_epInfo'])
+            if 'episode' not in epsEt:
+                return False
 
             seasons = epsEt['episodelist']['season']
             if not isinstance(seasons, list):


### PR DESCRIPTION
Addresses Traceback TypeError: list indices must be integers, not str. Is sometimes raised when doing a Force Full Update.
