### PR TITLE
Fix adding shows from TVRage API plus sorting them in Layout Simple of S...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,12 +32,14 @@
 * Change suppress HTTPS verification InsecureRequestWarning as many sites use self-certified certificates
 * Fix API endpoint Episode.SetStatus to "Wanted"
 * Change airdateModifyStamp to handle hour that is "00:00"
-* Fix a handler when ShowData is not available in tvdb and tvrage APIs
-* Fix a handler when EpisodeData is not available in tvdb and tvrage APIs
+* Fix a handler when ShowData is not available in TVDB and TVRage APIs
+* Fix a handler when EpisodeData is not available in TVDB and TVRage APIs
+* Add TVRage "Canceled/Ended" as "Ended" status to sort on Simple Layout of Show List page
 * Fix qtips on Display Show and Config Post Processing
 
 [develop changelog]
 * Fix typo for commit "ShowData handler" i.e. SHA-1:3eec217
+* Fix adding show from TVRage API
 
 
 ### 0.3.1 (2014-11-19 16:40:00 UTC)

--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -280,10 +280,13 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
     #set $cur_downloaded = 0
     #set $cur_total = 0
     #set $download_stat_tip = ''
-    #if None is not $curShow.status and re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
-	    #set $display_status = 'Continuing'
-    #else
-        #set $display_status = $curShow.status
+    #set $display_status = $curShow.status
+    #if None is not $display_status
+        #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
+            #set $display_status = 'Continuing'
+        #else if re.search(r'(?i)(?:nded)', $curShow.status)
+            #set $display_status = 'Ended'
+        #end if
     #end if
 
     #if $curShow.indexerid in $show_stat:
@@ -396,7 +399,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 				</td>
 				
 				<td class="show-table">
-				    #if $layout != 'simple':	
+				    #if $layout != 'simple':
 						#if $curShow.network:
 							<img class="show-network-image" src="$sbRoot/images/network/${curShow.network.replace(u"\u00C9",'e').lower()}.png" alt="$curShow.network" title="$curShow.network" />	
 						#else:
@@ -404,7 +407,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 						#end if
 					#else:
 						$curShow.network
-					#end if	
+					#end if
 				</td>
 				
 				<td class="show-table">
@@ -420,8 +423,8 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 	</div>
   
 
-    
-#end for    
+
+#end for
 </div> 
 </div> 
 
@@ -604,11 +607,16 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 		</td>
 		
         <td align="center">
-#if None is not $curShow.status and re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
-			Continuing
-#else:
-			$curShow.status
+
+#set $display_status = $curShow.status
+#if None is not $display_status
+    #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
+        #set $display_status = 'Continuing'
+    #else if re.search(r'(?i)(?:nded)', $curShow.status)
+        #set $display_status = 'Ended'
+    #end if
 #end if
+			$display_status
 		</td>
 		
     </tr>

--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -604,7 +604,7 @@ class TVRage:
 
             self.config['params_epInfo']['sid'] = sid
             epsEt = self._getetsrc(self.config['url_epInfo'], self.config['params_epInfo'])
-            if 'episode' not in epsEt:
+            if 'episodelist' not in epsEt and 'season' not in epsEt['episodelist']:
                 return False
 
             seasons = epsEt['episodelist']['season']


### PR DESCRIPTION
Show failed to be added from TVRage API with "show contains no season/episode data" error.
Change TVRage "Canceled/Ended" to "Ended" status to correct the sort on Simple Layout of Show List page.
