### PR TITLE
Change overhaul Config/Search Providers plus fix a couple of config links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,13 @@
 * Add TVRage "Canceled/Ended" as "Ended" status to sort on Simple Layout of Show List page
 * Fix qtips on Display Show and Config Post Processing
 * Fix glitch above rating stars on Display Show page
+* Change overhaul Config/Search Providers
+* Change Config/Search Providers texts and descriptions
+* Fix display when no providers are visible on Config/Search Providers
+* Fix failing "Search Settings" link that is shown on Config/Search Providers when Torrents Search is not enabled
+* Fix failing "Providers" link on Config/Search Settings/Episode Search
+* Change case of labels in General Config/Interface/Timezone
+* Split enabled from not enabled providers in the Configure Provider drop down on the Providers Options tab 
 
 [develop changelog]
 * Fix typo for commit "ShowData handler" i.e. SHA-1:3eec217

--- a/gui/slick/css/dark.css
+++ b/gui/slick/css/dark.css
@@ -1455,17 +1455,11 @@ config*.tmpl
 	min-height: 200px;
 }
 
-.component-group-desc{
-	float: left;
-	width: 250px;
-}
-
 .component-group-desc h3{
 	margin-top: 5px;
 }
 
 .component-group-desc p {
-	width: 90%;
 	margin: 10px 0;
 	color: #ddd;
 }
@@ -1523,16 +1517,8 @@ select .selected {
 
 #provider_order_list li, 
 #service_order_list li {
-	padding: 5px;
-	margin: 5px 0;
-	font-size: 14px;
 	background: #333 !important;
 	color: #fff;
-}
-
-#provider_order_list input, 
-#service_order_list input {
-	margin: 0px 2px;
 }
 
 #config .tip_scale label span.component-title {
@@ -2054,19 +2040,8 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 }
 
 .btn {
-	display: inline-block;
-	*display: inline;
-	padding: 4px 10px 4px;
-	margin-bottom: 0;
-	*margin-left: .3em;
-	font-size: 12px;
-	line-height: 16px;
-	*line-height: 20px;
 	color: #fff;
-	text-align: center;
 	text-shadow: 0 1px 1px rgba(0, 0, 0, 0.75);
-	vertical-align: middle;
-	cursor: pointer;
 	background-color: #2672B6;
 	*background-color: #2672B6;
 	background-image: -ms-linear-gradient(top, #297AB8, #15528F);
@@ -2075,18 +2050,12 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 	background-image: -o-linear-gradient(top, #297AB8, #15528F);
 	background-image: linear-gradient(top, #297AB8, #15528F);
 	background-image: -moz-linear-gradient(top, #297AB8, #15528F);
-	background-repeat: repeat-x;
 	border: 1px solid #111;
-	*border: 0;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 	border-color: #111 #111 #111;
 	border-bottom-color: #111;
-	-webkit-border-radius: 4px;
-	-moz-border-radius: 4px;
-	border-radius: 4px;
 	filter: progid:dximagetransform.microsoft.gradient(startColorstr='#297AB8', endColorstr='#15528F', GradientType=0);
 	filter: progid:dximagetransform.microsoft.gradient(enabled=false);
-	*zoom: 1;
 	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.0), 0 1px 2px rgba(0, 0, 0, 0.05);
 	-moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.0), 0 1px 2px rgba(0, 0, 0, 0.05);
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.0), 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -2428,6 +2397,15 @@ pre {
 /* =======================================================================
 input sizing (for config pages)
 ========================================================================== */
+#editAProvider optgroup {
+	color: #eee;
+    background-color: rgb(51, 51, 51);
+}
+
+#editAProvider optgroup option {
+	color: #222;
+    background-color: #fff;
+}
 
 #config select {
 	min-width: 0;

--- a/gui/slick/css/light.css
+++ b/gui/slick/css/light.css
@@ -1437,17 +1437,12 @@ config*.tmpl
 	min-height: 200px;
 }
 
-.component-group-desc{
-	float: left;
-	width: 250px;
-}
 
 .component-group-desc h3{
 	margin-top: 5px;
 }
 
 .component-group-desc p {
-	width: 90%;
 	margin: 10px 0;
 	color: #666;
 }
@@ -1501,18 +1496,6 @@ select .selected {
 	width: 250px;
 	padding-left: 20px;
 	list-style-type: none;
-}
-
-#provider_order_list li, 
-#service_order_list li {
-	padding: 5px;
-	margin: 5px 0;
-	font-size: 14px;
-}
-
-#provider_order_list input, 
-#service_order_list input {
-	margin: 0px 2px;
 }
 
 #config .tip_scale label span.component-title {
@@ -2034,19 +2017,8 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 }
 
 .btn {
-	display: inline-block;
-	*display: inline;
-	padding: 4px 10px 4px;
-	margin-bottom: 0;
-	*margin-left: .3em;
-	font-size: 12px;
-	line-height: 16px;
-	*line-height: 20px;
 	color: #333333;
-	text-align: center;
 	text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
-	vertical-align: middle;
-	cursor: pointer;
 	background-color: #f5f5f5;
 	*background-color: #e6e6e6;
 	background-image: -ms-linear-gradient(top, #ffffff, #e6e6e6);
@@ -2055,18 +2027,12 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 	background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
 	background-image: linear-gradient(top, #ffffff, #e6e6e6);
 	background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
-	background-repeat: repeat-x;
 	border: 1px solid #cccccc;
-	*border: 0;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 	border-color: #e6e6e6 #e6e6e6 #bfbfbf;
 	border-bottom-color: #b3b3b3;
-	-webkit-border-radius: 4px;
-	-moz-border-radius: 4px;
-	border-radius: 4px;
 	filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffffff', endColorstr='#e6e6e6', GradientType=0);
 	filter: progid:dximagetransform.microsoft.gradient(enabled=false);
-	*zoom: 1;
 	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 	-moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -2404,6 +2370,15 @@ pre {
 /* =======================================================================
 input sizing (for config pages)
 ========================================================================== */
+#editAProvider optgroup {
+	color: #eee;
+    background-color: #888;
+}
+
+#editAProvider optgroup option {
+	color: #222;
+    background-color: #fff;
+}
 
 #config select {
 	min-width: 0;

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1526,6 +1526,7 @@ config*.tmpl
 .component-group-desc{
 	float: left;
 	width: 250px;
+	padding-right: 10px;
 }
 
 .component-group-desc h3{
@@ -1533,7 +1534,6 @@ config*.tmpl
 }
 
 .component-group-desc p {
-	width: 90%;
 	margin: 10px 0;
 	color: #666;
 }
@@ -1544,7 +1544,7 @@ config*.tmpl
 
 #config div.field-pair select,
 #config div.field-pair input {
-	margin-right: 6px;
+	margin-right: 15px;
 }
 
 #config div.field-pair input {
@@ -1572,7 +1572,7 @@ config*.tmpl
 }
 
 #config label.space-right {
-	margin-right:10px
+	margin-right:20px
 }
 #config .metadataDiv {
 	display: none;
@@ -1612,16 +1612,56 @@ select .selected {
 	list-style-type: none;
 }
 
-#provider_order_list li, 
+#config.search_providers #core-component-group1 #provider_key h4 {
+	display: inline-block;
+	float: left;
+	margin: 0;
+}
+
+#config.search_providers #core-component-group1 #provider_key p {
+	margin: 0 0 20px 30px;
+}
+
+#config.search_providers #core-component-group1 .component-group-desc,
+#config.search_providers #provider_order_list,
+#config.search_providers #core-component-group1 #provider_key {
+	width: 300px
+}
+
+#config.search_providers #provider_order_list {
+	padding: 0;
+	float: left
+}
+
+#config.search_providers #provider_order_list,
+#config.search_providers #core-component-group1 .btn {
+	margin: 0 auto
+}
+
+#config.search_providers #core-component-group1 .btn {
+	display: block
+}
+
+#config.search_providers #core-component-group1 #provider_key {
+	float: right;
+	margin-bottom:25px
+}
+
+#provider_order_list li,
 #service_order_list li {
 	padding: 5px;
-	margin: 5px 0;
+	margin: 0 0 5px;
 	font-size: 14px;
 }
 
 #provider_order_list input, 
 #service_order_list input {
-	margin: 0px 2px;
+	margin: 0 5px 0 2px;
+	vertical-align: middle;
+}
+
+#provider_order_list a.imgLink {
+	margin-right: 3px
 }
 
 #config .tip_scale label span.component-title {
@@ -2178,34 +2218,15 @@ fieldset[disabled] .navbar-default .btn-link:focus {
 	font-size: 12px;
 	line-height: 16px;
 	*line-height: 20px;
-	color: #333333;
 	text-align: center;
-	text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
 	vertical-align: middle;
 	cursor: pointer;
-	background-color: #f5f5f5;
-	*background-color: #e6e6e6;
-	background-image: -ms-linear-gradient(top, #ffffff, #e6e6e6);
-	background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#e6e6e6));
-	background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
-	background-image: -o-linear-gradient(top, #ffffff, #e6e6e6);
-	background-image: linear-gradient(top, #ffffff, #e6e6e6);
-	background-image: -moz-linear-gradient(top, #ffffff, #e6e6e6);
 	background-repeat: repeat-x;
-	border: 1px solid #cccccc;
 	*border: 0;
-	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-	border-color: #e6e6e6 #e6e6e6 #bfbfbf;
-	border-bottom-color: #b3b3b3;
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
-	filter: progid:dximagetransform.microsoft.gradient(startColorstr='#ffffff', endColorstr='#e6e6e6', GradientType=0);
-	filter: progid:dximagetransform.microsoft.gradient(enabled=false);
 	*zoom: 1;
-	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-	-moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .btn:hover,
@@ -3062,7 +3083,7 @@ span.token-input-delete-token {
 	width: 100%;
 	height: 100%;
 	z-index: 0;
-	background-image: url(/images/poster-dark.jpg)
+	background-image: url(../images/poster-dark.jpg)
 }
 /* =======================================================================
 jquery.confirm.css
@@ -3074,7 +3095,7 @@ jquery.confirm.css
 	position: fixed;
 	top: 0;
 	left: 0;
-	background: url('../images/bg.gif');
+	background: url(../images/bg.gif);
 	background: -moz-linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)) repeat-x rgba(0,0,0,0.5);
 	background:-webkit-gradient(linear, 0% 0%, 0% 100%, from(rgba(0,0,0,0.5)), to(rgba(0,0,0,0.5))) repeat-x rgba(0,0,0,0.5);
 	z-index: 100000;
@@ -3102,13 +3123,13 @@ jquery.confirm.css
 	color: #fff;
 	margin: 0;
 	font-size: 22px;
-	text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.75);
+	text-shadow: 0 1px 1px rgba(0, 0, 0, 0.75);
 }
 
 #confirmBox p {
 	padding-top: 20px;
 	color: #000;
-	text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.75);
+	text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
 }
 
 #confirmButtons {

--- a/gui/slick/interfaces/default/config_general.tmpl
+++ b/gui/slick/interfaces/default/config_general.tmpl
@@ -282,10 +282,10 @@
 							<span class="component-title">Timezone:</span>
 							<span class="component-desc">
 								<label for="local" class="space-right">
-									<input type="radio" name="timezone_display" id="local" value="local" #if "local" == $sickbeard.TIMEZONE_DISPLAY then 'checked="checked"' else ''# />Local
+									<input type="radio" name="timezone_display" id="local" value="local" #if "local" == $sickbeard.TIMEZONE_DISPLAY then 'checked="checked"' else ''# />local
 								</label>
 								<label for="network">
-									<input type="radio" name="timezone_display" id="network" value="network" #if "network" == $sickbeard.TIMEZONE_DISPLAY then 'checked="checked"' else ''# />Network
+									<input type="radio" name="timezone_display" id="network" value="network" #if "network" == $sickbeard.TIMEZONE_DISPLAY then 'checked="checked"' else ''# />network
 								</label>
 								<div class="clear-left"><p>display dates and times in either your timezone or the shows network timezone</p></div>
 							</span>

--- a/gui/slick/interfaces/default/config_providers.tmpl
+++ b/gui/slick/interfaces/default/config_providers.tmpl
@@ -6,710 +6,766 @@
 #set global $title="Config - Providers"
 #set global $header="Search Providers"
 
-#set global $sbPath="../.."
+#set global $sbPath = '../..'
 
-#set global $topmenu="config"#
+#set global $topmenu = 'config'
 #import os.path
-#include $os.path.join($sickbeard.PROG_DIR, "gui/slick/interfaces/default/inc_top.tmpl")
+#include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 
 #if $varExists('header') 
-    <h1 class="header">$header</h1>
+	<h1 class="header">$header</h1>
 #else 
-    <h1 class="title">$title</h1>
+	<h1 class="title">$title</h1>
 #end if
+
+#set $html_selected = ' selected="selected"'
+#set $html_checked = 'checked="checked" '
+
 <script type="text/javascript" src="$sbRoot/js/configProviders.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
-#if $sickbeard.USE_NZBS
+
+#set $methods_notused = []
+#if not $sickbeard.USE_NZBS
+    $methods_notused.append('Newznab')
+#end if
+#if not $sickbeard.USE_TORRENTS
+    $methods_notused.append('Torrent')
+#end if
+
+#if $sickbeard.USE_NZBS or $sickbeard.USE_TORRENTS
 <script type="text/javascript" charset="utf-8">
 <!--
 \$(document).ready(function(){
-var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
-#for $curNewznabProvider in $sickbeard.newznabProviderList:
-\$(this).addProvider('$curNewznabProvider.getID()', '$curNewznabProvider.name', '$curNewznabProvider.url', '$curNewznabProvider.key', '$curNewznabProvider.catIDs', $int($curNewznabProvider.default), show_nzb_providers);
-#end for
+
+    #if $sickbeard.USE_NZBS
+
+    var show_nzb_providers = <%= 'true' if sickbeard.USE_NZBS else 'false' %>;
+
+        #for $curNewznabProvider in $sickbeard.newznabProviderList:
+
+    \$(this).addProvider('$curNewznabProvider.getID()', '$curNewznabProvider.name', '$curNewznabProvider.url', '$curNewznabProvider.key', '$curNewznabProvider.catIDs', $int($curNewznabProvider.default), show_nzb_providers);
+
+        #end for
+
+    #end if
+
+    #if $sickbeard.USE_TORRENTS
+
+        #for $curTorrentRssProvider in $sickbeard.torrentRssProviderList:
+
+    \$(this).addTorrentRssProvider('$curTorrentRssProvider.getID()', '$curTorrentRssProvider.name', '$curTorrentRssProvider.url', '$curTorrentRssProvider.cookies');
+
+        #end for
+
+    #end if
 });
 //-->
 </script>
 #end if
+
+<div id="config" class="search_providers">
+	<div id="config-content">
+
+		<form id="configForm" action="saveProviders" method="post">
+
+			<div id="config-components">
+				<ul>
+					<li><a href="#core-component-group1">Provider Priorities</a></li>
+					<li><a href="#core-component-group2">Provider Options</a></li>
+
+#if $sickbeard.USE_NZBS
+					<li><a href="#core-component-group3">Configure Custom Newznab Providers</a></li>
+#end if
+#if $sickbeard.USE_TORRENTS
+					<li><a href="#core-component-group4">Configure Custom Torrent Providers</a></li>
+#end if
+				</ul>
+
+
+
+				<div id="core-component-group1" class="component-group">
+					<fieldset class="component-group-list">
+						<div class="component-group-desc">
+							<h3>Provider Priorities</h3>
+							<p>Check off and drag the providers into the order you want them to be used.</p>
+							<p>At least one provider is required but two are recommended.</p>
+
+#if $methods_notused
+							<blockquote style="margin: 20px 0"><%= '/'.join(x for x in methods_notused) %> providers can be enabled in <a href="$sbRoot/config/search/">Search Settings</a></blockquote>
+#else
+							<br/>
+#end if
+						</div>
+
+
+						<ul id="provider_order_list" class="provider_order_panel">
+#for $curProvider in $sickbeard.providers.sortedProviderList()
+    #if $curProvider.providerType == $GenericProvider.NZB and not $sickbeard.USE_NZBS
+        #continue
+    #elif $curProvider.providerType == $GenericProvider.TORRENT and not $sickbeard.USE_TORRENTS
+        #continue
+    #end if
+    #set $curName = $curProvider.getID()
+						  <li class="ui-state-default" id="$curName">
+							<input type="checkbox" id="enable_$curName" class="provider_enabler" <%= html_checked if curProvider.isEnabled() else '' %>/>
+                            <a href="<%= anon_url(curProvider.url) %>" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="$curProvider.name" title="$curProvider.name" width="16" height="16" style="vertical-align:middle;"/></a>
+							<span style="vertical-align:middle;">$curProvider.name</span>
+<%= '*' if not curProvider.supportsBacklog else '' %>
+<%= '**' if 'EZRSS' == curProvider.name else '' %>
+							<span class="ui-icon ui-icon-arrowthick-2-n-s pull-right" style="margin-top:3px"></span>
+						  </li>
+#end for
+						</ul>
+
+
+						<div id="provider_key">
+							<h4 class="note">*</h4><p class="note">Provider does not support backlog searches at this time</p>
+#if $sickbeard.USE_TORRENTS
+							<h4 class="note">**</h4><p class="note">Provider supports <b>limited</b> backlog searches, some episodes/qualities may not be available</p>
+#end if
+							##<h4 class="note">!</h4><p class="note">Provider is <b>NOT WORKING</b></p>
+						</div>
+
+						<input type="hidden" name="provider_order" id="provider_order" value="<%=" ".join([x.getID()+':'+str(int(x.isEnabled())) for x in sickbeard.providers.sortedProviderList()])%>"/>
+						<div style="width: 300px; float: right">
+							<div style="margin: 0px auto; width: 101px">
+								<input type="submit" class="btn config_submitter" value="Save Changes" />
+							</div>
+						</div>
+					</fieldset>
+
+				</div><!-- /component-group1 //-->
+
+
+
+				<div id="core-component-group2" class="component-group">
+
+					<div class="component-group-desc">
+						<h3>Provider Options</h3>
+						<p>Configure individual provider settings here.</p>
+					</div>
+
+					<fieldset class="component-group-list">
+						<div class="field-pair">
+							<label for="editAProvider">
+								<span class="component-title">Configure provider:</span>
+								<span class="component-desc">
+#set $provider_config_list_enabled = []
+#set $provider_config_list = []
+#for $curProvider in $sickbeard.providers.sortedProviderList()
+    #if $curProvider.providerType == $GenericProvider.NZB and not $sickbeard.USE_NZBS
+        #continue
+    #elif $curProvider.providerType == $GenericProvider.TORRENT and not $sickbeard.USE_TORRENTS
+        #continue
+    #end if
+    #if $curProvider.isEnabled()
+        $provider_config_list_enabled.append($curProvider)
+    #else
+        $provider_config_list.append($curProvider)
+    #end if
+#end for
+
+#if $provider_config_list + $provider_config_list_enabled
+									<select id="editAProvider" class="form-control input-sm">
+    #if $provider_config_list_enabled
+										<optgroup label="Enabled...">
+        #for $cur_provider in $provider_config_list_enabled:
+											<option value="$cur_provider.getID()">$cur_provider.name</option>
+        #end for
+										</optgroup>
+    #end if
+    #if $provider_config_list
+										<optgroup label="Not Enabled...">
+        #for $cur_provider in $provider_config_list
+											<option value="$cur_provider.getID()">$cur_provider.name</option>
+        #end for
+										</optgroup>
+    #end if
+									</select><p>note: must refresh browser after saving enabled providers for an up to date list</p>
+#else
+									<p>No providers available to configure</p>
+#end if
+								</span>
+							</label>
+						</div>
+
+
+					<!-- start div for editing providers //-->
+#for $curNewznabProvider in [$curProvider for $curProvider in $sickbeard.newznabProviderList]
+					<div class="providerDiv" id="${curNewznabProvider.getID()}Div">
+    #if $curNewznabProvider.default and $curNewznabProvider.needs_auth
+						<div class="field-pair">
+							<label for="${curNewznabProvider.getID()}_url">
+								<span class="component-title">URL</span>
+								<span class="component-desc">
+									<input type="text" id="${curNewznabProvider.getID()}_url" value="$curNewznabProvider.url" class="form-control input-sm input350" disabled/>
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="${curNewznabProvider.getID()}_hash">
+								<span class="component-title">API key</span>
+								<span class="component-desc">
+									<input type="text" id="${curNewznabProvider.getID()}_hash" value="$curNewznabProvider.key" newznab_name="${curNewznabProvider.getID()}_hash" class="newznab_key form-control input-sm input350" />
+									<div class="clear-left"><p>get API key from provider website</p></div>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNewznabProvider, 'enable_daily'):
+						<div class="field-pair">
+							<label for="${curNewznabProvider.getID()}_enable_daily">
+								<span class="component-title">Enable daily searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNewznabProvider.getID()}_enable_daily" id="${curNewznabProvider.getID()}_enable_daily" <%= html_checked if curNewznabProvider.enable_daily else '' %>/>
+									<p>perform daily searches at provider</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNewznabProvider, 'enable_backlog'):
+						<div class="field-pair">
+							<label for="${curNewznabProvider.getID()}_enable_backlog">
+								<span class="component-title">Enable backlog searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNewznabProvider.getID()}_enable_backlog" id="${curNewznabProvider.getID()}_enable_backlog" <%= html_checked if curNewznabProvider.enable_backlog else '' %>/>
+									<p>perform backlog searches at provider</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNewznabProvider, 'search_mode'):
+						<div class="field-pair">
+							<span class="component-title">Season search mode</span>
+							<span class="component-desc">
+								<label class="space-right">
+									<input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_sponly" value="sponly" <%= html_checked if 'sponly' == curNewznabProvider.search_mode else '' %>/>season packs only
+								</label>
+								<label>
+									<input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_eponly" value="eponly" <%= html_checked if 'eponly' == curNewznabProvider.search_mode else '' %>/>episodes only
+								</label>
+								<p>when searching for complete seasons, search for packs or collect single episodes</p>
+							</span>
+						</div>
+    #end if
+
+    #if $hasattr($curNewznabProvider, 'search_fallback'):
+						<div class="field-pair">
+							<label for="${curNewznabProvider.getID()}_search_fallback">
+								<span class="component-title">Season search fallback</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNewznabProvider.getID()}_search_fallback" id="${curNewznabProvider.getID()}_search_fallback" <%= html_checked if curNewznabProvider.search_fallback else '' %>/>
+									<p>run the alternate season search mode when a complete season is not found</p>
+								</span>
+							</label>
+						</div>
+    #end if
+					</div>
+#end for
+
+#for $curNzbProvider in [$curProvider for $curProvider in $sickbeard.providers.sortedProviderList() if $curProvider.providerType == $GenericProvider.NZB and $curProvider not in $sickbeard.newznabProviderList]:
+					<div class="providerDiv" id="${curNzbProvider.getID()}Div">
+    #if $hasattr($curNzbProvider, 'username'):
+						<div class="field-pair">
+							<label for="${curNzbProvider.getID()}_username">
+								<span class="component-title">Username</span>
+								<span class="component-desc">
+									<input type="text" name="${curNzbProvider.getID()}_username" value="$curNzbProvider.username" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNzbProvider, 'api_key'):
+						<div class="field-pair">
+							<label for="${curNzbProvider.getID()}_api_key">
+								<span class="component-title">API key</span>
+								<span class="component-desc">
+									<input type="text" name="${curNzbProvider.getID()}_api_key" value="$curNzbProvider.api_key" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+
+    #if $hasattr($curNzbProvider, 'enable_daily'):
+						<div class="field-pair">
+							<label for="${curNzbProvider.getID()}_enable_daily">
+								<span class="component-title">Enable daily searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNzbProvider.getID()}_enable_daily" id="${curNzbProvider.getID()}_enable_daily" <%= html_checked if curNzbProvider.enable_daily else '' %>/>
+									<p>enable provider to perform daily searches.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNzbProvider, 'enable_backlog'):
+						<div class="field-pair">
+							<label for="${curNzbProvider.getID()}_enable_backlog">
+								<span class="component-title">Enable backlog searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNzbProvider.getID()}_enable_backlog" id="${curNzbProvider.getID()}_enable_backlog" <%= html_checked if curNzbProvider.enable_backlog else '' %>/>
+									<p>enable provider to perform backlog searches.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNzbProvider, 'search_fallback'):
+						<div class="field-pair">
+							<label for="${curNzbProvider.getID()}_search_fallback">
+								<span class="component-title">Season search fallback</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curNzbProvider.getID()}_search_fallback" id="${curNzbProvider.getID()}_search_fallback" <%= html_checked if curNzbProvider.search_fallback else '' %>/>
+									<p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curNzbProvider, 'search_mode'):
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Season search mode</span>
+								<span class="component-desc">
+									<p>when searching for complete seasons you can choose to have it look for season packs only, or choose to have it build a complete season from just single episodes.</p>
+								</span>
+							</label>
+							<label>
+								<span class="component-title"></span>
+								<span class="component-desc">
+									<input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_sponly" value="sponly" <%= html_checked if 'sponly' == curNzbProvider.search_mode else '' %>/>season packs only.
+								</span>
+							</label>
+							<label>
+								<span class="component-title"></span>
+								<span class="component-desc">
+									<input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_eponly" value="eponly" <%= html_checked if 'eponly' == curNzbProvider.search_mode else '' %>/>episodes only.
+								</span>
+							</label>
+						</div>
+    #end if
+
+					</div>
+#end for
+
+#for $curTorrentProvider in [$curProvider for $curProvider in $sickbeard.providers.sortedProviderList() if $curProvider.providerType == $GenericProvider.TORRENT]:
+					<div class="providerDiv" id="${curTorrentProvider.getID()}Div">
+    #if $hasattr($curTorrentProvider, 'api_key'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_api_key">
+								<span class="component-title">Api key:</span>
+								<span class="component-desc">
+									<input type="text" name="${curTorrentProvider.getID()}_api_key" id="${curTorrentProvider.getID()}_api_key" value="$curTorrentProvider.api_key" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'digest'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_digest">
+								<span class="component-title">Digest:</span>
+								<span class="component-desc">
+									<input type="text" name="${curTorrentProvider.getID()}_digest" id="${curTorrentProvider.getID()}_digest" value="$curTorrentProvider.digest" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'hash'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_hash">
+								<span class="component-title">Hash:</span>
+								<span class="component-desc">
+									<input type="text" name="${curTorrentProvider.getID()}_hash" id="${curTorrentProvider.getID()}_hash" value="$curTorrentProvider.hash" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'username'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_username">
+								<span class="component-title">Username:</span>
+								<span class="component-desc">
+									<input type="text" name="${curTorrentProvider.getID()}_username" id="${curTorrentProvider.getID()}_username" value="$curTorrentProvider.username" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'password'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_password">
+								<span class="component-title">Password:</span>
+								<span class="component-desc">
+									<input type="password" name="${curTorrentProvider.getID()}_password" id="${curTorrentProvider.getID()}_password" value="$curTorrentProvider.password" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'passkey'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_passkey">
+								<span class="component-title">Passkey:</span>
+								<span class="component-desc">
+									<input type="text" name="${curTorrentProvider.getID()}_passkey" id="${curTorrentProvider.getID()}_passkey" value="$curTorrentProvider.passkey" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'ratio'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_ratio">
+								<span class="component-title" id="${curTorrentProvider.getID()}_ratio_desc">Seed ratio:</span>
+								<span class="component-desc">
+									<input type="number" step="0.1" name="${curTorrentProvider.getID()}_ratio" id="${curTorrentProvider.getID()}_ratio" value="$curTorrentProvider.ratio" class="form-control input-sm input75" />
+								</span>
+							</label>
+							<label>
+								<span class="component-title">&nbsp;</span>
+								<span class="component-desc">
+									<p>stop transfer when ratio is reached<br>(-1 SickGear default to seed forever, or leave blank for downloader default)</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'minseed'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_minseed">
+								<span class="component-title" id="${curTorrentProvider.getID()}_minseed_desc">Minimum seeders:</span>
+								<span class="component-desc">
+									<input type="number" name="${curTorrentProvider.getID()}_minseed" id="${curTorrentProvider.getID()}_minseed" value="$curTorrentProvider.minseed" class="form-control input-sm input75" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'minleech'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_minleech">
+								<span class="component-title" id="${curTorrentProvider.getID()}_minleech_desc">Minimum leechers:</span>
+								<span class="component-desc">
+									<input type="number" name="${curTorrentProvider.getID()}_minleech" id="${curTorrentProvider.getID()}_minleech" value="$curTorrentProvider.minleech" class="form-control input-sm input75" />
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'proxy'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_proxy">
+								<span class="component-title">Access provider via proxy</span>
+								<span class="component-desc">
+									<input type="checkbox" class="enabler" name="${curTorrentProvider.getID()}_proxy" id="${curTorrentProvider.getID()}_proxy" <%= html_checked if curTorrentProvider.proxy.enabled else '' %>/>
+									<p>to bypass country blocking mechanisms</p>
+								</span>
+							</label>
+						</div>
+
+        #if $hasattr($curTorrentProvider.proxy, 'url'):
+						<div class="field-pair content_${curTorrentProvider.getID()}_proxy" id="content_${curTorrentProvider.getID()}_proxy">
+							<label for="${curTorrentProvider.getID()}_proxy_url">
+								<span class="component-title">Proxy URL:</span>
+								<span class="component-desc">
+								  <select name="${curTorrentProvider.getID()}_proxy_url" id="${curTorrentProvider.getID()}_proxy_url" class="form-control input-sm">
+            #for $i in $curTorrentProvider.proxy.urls.keys():
+									<option value="$curTorrentProvider.proxy.urls[$i]" <%= html_selected if curTorrentProvider.proxy.url == curTorrentProvider.proxy.urls[i] else '' %>>$i</option>
+            #end for
+									</select>
+								</span>
+							</label>
+						</div>
+        #end if
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'confirmed'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_confirmed">
+								<span class="component-title">Confirmed download</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" <%= html_checked if curTorrentProvider.confirmed else '' %>/>
+									<p>only download torrents from trusted or verified uploaders ?</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'freeleech'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_freeleech">
+								<span class="component-title">Freeleech</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curTorrentProvider.getID()}_freeleech" id="${curTorrentProvider.getID()}_freeleech" <%= html_checked if curTorrentProvider.freeleech else '' %>/>
+									<p>only download <b>[FreeLeech]</b> torrents.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'enable_daily'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_enable_daily">
+								<span class="component-title">Enable daily searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curTorrentProvider.getID()}_enable_daily" id="${curTorrentProvider.getID()}_enable_daily" <%= html_checked if curTorrentProvider.enable_daily else '' %>/>
+									<p>enable provider to perform daily searches.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'enable_backlog'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_enable_backlog">
+								<span class="component-title">Enable backlog searches</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curTorrentProvider.getID()}_enable_backlog" id="${curTorrentProvider.getID()}_enable_backlog" <%= html_checked if curTorrentProvider.enable_backlog else '' %>/>
+									<p>enable provider to perform backlog searches.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'search_fallback'):
+						<div class="field-pair">
+							<label for="${curTorrentProvider.getID()}_search_fallback">
+								<span class="component-title">Season search fallback</span>
+								<span class="component-desc">
+									<input type="checkbox" name="${curTorrentProvider.getID()}_search_fallback" id="${curTorrentProvider.getID()}_search_fallback" <%= html_checked if curTorrentProvider.search_fallback else '' %>/>
+									<p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'search_mode'):
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Season search mode</span>
+								<span class="component-desc">
+									<p>when searching for complete seasons you can choose to have it look for season packs only, or choose to have it build a complete season from just single episodes.</p>
+								</span>
+							</label>
+							<label>
+								<span class="component-title"></span>
+								<span class="component-desc">
+									<input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_sponly" value="sponly" <%= html_checked if 'sponly' == curTorrentProvider.search_mode else '' %>/>season packs only.
+								</span>
+							</label>
+							<label>
+								<span class="component-title"></span>
+								<span class="component-desc">
+									<input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_eponly" value="eponly" <%= html_checked if 'eponly' == curTorrentProvider.search_mode else '' %>/>episodes only.
+								</span>
+							</label>
+						</div>
+    #end if
+
+    #if $hasattr($curTorrentProvider, 'options'):
+						<br>
+						<input type="hidden" id="tvtorrents_option_string" />
+						<fieldset>
+						<legend id="seed_options">Advanced options</legend>
+						<div class="field-pair">
+							<label >
+								<span class="component-title">Seeding ratio(%) goal:</span>
+									<input type="text" id="tvtorrents_seed_ratio" class="seed_option form-control input-sm input75" />
+							</label>
+						</div>
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Seeding time(h) goal:</span>
+								<input type="text" id="tvtorrents_seed_time" class="seed_option form-control input-sm input75" />
+							</label>
+						</div>
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Process method:</span>
+								<select id="tvtorrents_process_method" class="seed_option form-control input-sm" >
+        #set $process_method_text = {'': "", 'copy': "Copy", 'move': "Move", 'hardlink': "Hard Link", 'symlink' : "Symbolic Link"}
+        #for $curAction in ('', 'copy', 'move', 'hardlink', 'symlink'):
+            #set $process_method = ''
+										<option class="seed_option" value="$curAction" $process_method>$process_method_text[$curAction]</option>
+        #end for
+								</select>
+							</label>
+						</div>
+						</fieldset>
+						<br>
+    #end if
+
+					</div>
+#end for
+					<!-- end div for editing providers -->
+#if $provider_config_list
+					<input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
+#end  if
+					</fieldset>
+				</div><!-- /component-group2 //-->
+
+
+
+#if $sickbeard.USE_NZBS
+
+				<div id="core-component-group3" class="component-group">
+
+					<div class="component-group-desc">
+						<h3>Configure Custom<br />Newznab Providers</h3>
+						<p>Add and setup or remove custom newznab providers.</p>
+					</div>
+
+					<fieldset class="component-group-list">
+						<div class="field-pair">
+							<label for="newznab_string">
+								<span class="component-title">Select provider:</span>
+								<span class="component-desc">
+									<input type="hidden" name="newznab_string" id="newznab_string" />
+									<select id="editANewznabProvider" class="form-control input-sm">
+										<option value="addNewznab">-- add new provider --</option>
+									</select>
+								</span>
+							</label>
+						</div>
+
+					<div class="newznabProviderDiv" id="addNewznab">
+						<div class="field-pair">
+							<label for="newznab_name">
+								<span class="component-title">Provider name</span>
+								<span class="component-desc">
+									<input type="text" id="newznab_name" class="form-control input-sm input200" />
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="newznab_url">
+								<span class="component-title">Site URL</span>
+								<span class="component-desc">
+									<input type="text" id="newznab_url" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="newznab_key">
+								<span class="component-title">API key</span>
+								<span class="component-desc">
+									<input type="text" id="newznab_key" class="form-control input-sm input350" />
+								</span>
+								<span class="component-desc">
+									<div class="clear-left"><p>note: enter 0 (zero) if not required</p></div>
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Search categories</span>
+								<span class="component-desc">
+									<select id="newznab_cap" multiple="multiple" style="min-width:10em;" ></select>
+									<select id="newznab_cat" multiple="multiple" style="min-width:10em;" ></select>
+									<div class="clear-left">
+										<p>select newznab categories to search on the left then "Update Categories"<br />
+										<b>remember</b> to "Save Changes"!</p>
+									</div>
+									<div class="clear-left"><input class="btn" type="button" class="newznab_cat_update" id="newznab_cat_update" value="Update Categories" /></div>
+								</span>
+							</label>
+						</div>
+
+						<div id="newznab_add_div">
+							<input class="btn" type="button" class="newznab_save" id="newznab_add" value="Add" />
+						</div>
+						<div id="newznab_update_div" style="display: none;">
+							<input class="btn btn-danger newznab_delete" type="button" class="newznab_delete" id="newznab_delete" value="Delete" />
+						</div>
+					</div>
+
+					</fieldset>
+				</div><!-- /component-group3 //-->
+#end if
+
+
 
 #if $sickbeard.USE_TORRENTS
-<script type="text/javascript" charset="utf-8">
-<!--
-\$(document).ready(function(){
-#for $curTorrentRssProvider in $sickbeard.torrentRssProviderList:
-    \$(this).addTorrentRssProvider('$curTorrentRssProvider.getID()', '$curTorrentRssProvider.name', '$curTorrentRssProvider.url', '$curTorrentRssProvider.cookies');
-#end for
-});
-//-->
-</script>
+
+				<div id="core-component-group4" class="component-group">
+
+				<div class="component-group-desc">
+					<h3>Configure Custom Torrent Providers</h3>
+					<p>Add or remove custom RSS providers.</p>
+				</div>
+
+				<fieldset class="component-group-list">
+					<div class="field-pair">
+						<label for="torrentrss_string">
+							<span class="component-title">Select provider</span>
+							<span class="component-desc">
+								<input type="hidden" name="torrentrss_string" id="torrentrss_string" />
+								<select id="editATorrentRssProvider" class="form-control input-sm">
+									<option value="addTorrentRss">-- add new provider --</option>
+								</select>
+							</span>
+						</label>
+					</div>
+
+					<div class="torrentRssProviderDiv" id="addTorrentRss">
+						<div class="field-pair">
+							<label for="torrentrss_name">
+								<span class="component-title">Provider name</span>
+								<span class="component-desc">
+									<input type="text" id="torrentrss_name" class="form-control input-sm input200" />
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="torrentrss_url">
+								<span class="component-title">RSS URL</span>
+								<span class="component-desc">
+									<input type="text" id="torrentrss_url" class="form-control input-sm input350" />
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="torrentrss_cookies">
+								<span class="component-title">Cookies:</span>
+								<span class="component-desc">
+									<input type="text" id="torrentrss_cookies" class="form-control input-sm input350" />
+									<p>eg. uid=xx;pass=yy</p>
+								</span>
+							</label>
+						</div>
+
+						<div id="torrentrss_add_div">
+							<input type="button" class="btn torrentrss_save" id="torrentrss_add" value="Add" />
+						</div>
+						<div id="torrentrss_update_div" style="display: none;">
+							<input type="button" class="btn btn-danger torrentrss_delete" id="torrentrss_delete" value="Delete" />
+						</div>
+					</div>
+				</fieldset>
+			</div><!-- /component-group4 //-->
 #end if
 
-<div id="config">
-    <div id="config-content">
 
-        <form id="configForm" action="saveProviders" method="post">
+			<br/><input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
 
-            <div id="config-components">
-                <ul>
-                    <li><a href="#core-component-group1">Provider Priorities</a></li>
-                    <li><a href="#core-component-group2">Provider Options</a></li>
-                  #if $sickbeard.USE_NZBS
-                    <li><a href="#core-component-group3">Configure Custom Newznab Providers</a></li>
-                  #end if
-                  #if $sickbeard.USE_TORRENTS
-                    <li><a href="#core-component-group4">Configure Custom Torrent Providers</a></li>
-                  #end if                  
-                </ul>
-                
-                <div id="core-component-group1" class="component-group">
+			</div><!-- /config-components //-->
 
-                    <div class="component-group-desc">
-                        <h3>Provider Priorities</h3>
-                        <p>Check off and drag the providers into the order you want them to be used.</p>
-                        <p>At least one provider is required but two are recommended.</p>
-
-                        #if not $sickbeard.USE_NZBS or not $sickbeard.USE_TORRENTS:
-                        <blockquote style="margin: 20px 0;">NZB/Torrent providers can be toggled in <b><a href="$sbRoot/config/search">Search Settings</a></b></blockquote>
-                        #else:
-                        <br/>
-                        #end if
-
-                        <div>
-                            <h4 class="note">*</h4><p class="note">Provider does not support backlog searches at this time.</p>
-                            <h4 class="note">**</h4><p class="note">Provider supports <b>limited</b> backlog searches, all episodes/qualities may not be available.</p>
-                            <h4 class="note">!</h4><p class="note">Provider is <b>NOT WORKING</b>.</p>
-                        </div>
-                    </div>
-
-                    <fieldset class="component-group-list">
-                        <ul id="provider_order_list">
-                        #for $curProvider in $sickbeard.providers.sortedProviderList():
-                            #if $curProvider.providerType == $GenericProvider.NZB and not $sickbeard.USE_NZBS:
-                                #continue
-                            #elif $curProvider.providerType == $GenericProvider.TORRENT and not $sickbeard.USE_TORRENTS:
-                                #continue
-                            #end if
-                            #set $curName = $curProvider.getID()
-                          <li class="ui-state-default" id="$curName">
-                            <input type="checkbox" id="enable_$curName" class="provider_enabler" #if $curProvider.isEnabled() then "checked=\"checked\"" else ""#/>
-                            <a href="<%= anon_url(curProvider.url) %>" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="$curProvider.name" title="$curProvider.name" width="16" height="16" style="vertical-align:middle;"/></a>
-                            <span style="vertical-align:middle;">$curProvider.name</span>
-                            #if not $curProvider.supportsBacklog then "*" else ""#
-                            #if $curProvider.name == "EZRSS" then "**" else ""#
-                            <span class="ui-icon ui-icon-arrowthick-2-n-s pull-right" style="vertical-align:middle;"></span>
-                          </li>
-                        #end for
-                        </ul>
-                        <input type="hidden" name="provider_order" id="provider_order" value="<%=" ".join([x.getID()+':'+str(int(x.isEnabled())) for x in sickbeard.providers.sortedProviderList()])%>"/>
-                        <br/><input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
-                    </fieldset>
-                </div><!-- /component-group1 //-->
-
-                <div id="core-component-group2" class="component-group">
-
-                    <div class="component-group-desc">
-                        <h3>Provider Options</h3>
-                        <p>Configure individual provider settings here.</p>
-                        <p>Check with provider's website on how to obtain an API key if needed.</p>
-                    </div>
-                    
-                    <fieldset class="component-group-list">
-                        <div class="field-pair">
-                            <label for="editAProvider">
-                                <span class="component-title">Configure provider:</span>
-                                <span class="component-desc">
-                                    #set $provider_config_list = []
-                                    #for $curProvider in $sickbeard.providers.sortedProviderList():
-                                        #if $curProvider.providerType == $GenericProvider.NZB and not $sickbeard.USE_NZBS:
-                                         #continue
-                                        #elif $curProvider.providerType == $GenericProvider.TORRENT and not $sickbeard.USE_TORRENTS:
-                                         #continue
-                                        #end if
-                                        $provider_config_list.append($curProvider)
-                                    #end for
-
-                                    #if $provider_config_list:                                        
-                                    <select id="editAProvider" class="form-control input-sm">
-                                        #for $cur_provider in $provider_config_list:
-                                            <option value="$cur_provider.getID()">$cur_provider.name</option>
-                                        #end for
-                                    </select>
-                                    #else:
-                                    No providers available to configure.
-                                    #end if
-                                </span>
-                            </label>
-                        </div>
-
-
-                    <!-- start div for editing providers //-->
-                    #for $curNewznabProvider in [$curProvider for $curProvider in $sickbeard.newznabProviderList]:
-                    <div class="providerDiv" id="${curNewznabProvider.getID()}Div">
-                        #if $curNewznabProvider.default and $curNewznabProvider.needs_auth
-                        <div class="field-pair">
-                            <label for="${curNewznabProvider.getID()}_url">
-                                <span class="component-title">URL:</span>
-                                <span class="component-desc">
-                                    <input type="text" id="${curNewznabProvider.getID()}_url" value="$curNewznabProvider.url" class="form-control input-sm input350" disabled/>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="${curNewznabProvider.getID()}_hash">
-                                <span class="component-title">API key:</span>
-                                <span class="component-desc">
-                                    <input type="text" id="${curNewznabProvider.getID()}_hash" value="$curNewznabProvider.key" newznab_name="${curNewznabProvider.getID()}_hash" class="newznab_key form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNewznabProvider, 'enable_daily'):
-                        <div class="field-pair">
-                            <label for="${curNewznabProvider.getID()}_enable_daily">
-                                <span class="component-title">Enable daily searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_daily" id="${curNewznabProvider.getID()}_enable_daily" #if $curNewznabProvider.enable_daily then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform daily searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-                        
-                        #if $hasattr($curNewznabProvider, 'enable_backlog'):
-                        <div class="field-pair">
-                            <label for="${curNewznabProvider.getID()}_enable_backlog">
-                                <span class="component-title">Enable backlog searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_backlog" id="${curNewznabProvider.getID()}_enable_backlog" #if $curNewznabProvider.enable_backlog then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform backlog searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNewznabProvider, 'search_fallback'):
-                        <div class="field-pair">
-                            <label for="${curNewznabProvider.getID()}_search_fallback">
-                                <span class="component-title">Season search fallback</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_search_fallback" id="${curNewznabProvider.getID()}_search_fallback" #if $curNewznabProvider.search_fallback then "checked=\"checked\"" else ""#/>
-                                    <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNewznabProvider, 'search_mode'):
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Season search mode</span>
-                                <span class="component-desc">
-                                    <p>when searching for complete seasons you can choose to have it look for season packs only, or choose to have it build a complete season from just single episodes.</p>
-                                </span>
-                            </label>
-                            <label> 
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_sponly" value="sponly" #if $curNewznabProvider.search_mode=="sponly" then "checked=\"checked\"" else ""# />season packs only.
-                                </span>
-                            </label>
-                            <label>
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_eponly" value="eponly" #if $curNewznabProvider.search_mode=="eponly" then "checked=\"checked\"" else ""# />episodes only.
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                    </div>
-                    #end for
-
-                    #for $curNzbProvider in [$curProvider for $curProvider in $sickbeard.providers.sortedProviderList() if $curProvider.providerType == $GenericProvider.NZB and $curProvider not in $sickbeard.newznabProviderList]:
-                    <div class="providerDiv" id="${curNzbProvider.getID()}Div">
-                        #if $hasattr($curNzbProvider, 'username'):
-                        <div class="field-pair">
-                            <label for="${curNzbProvider.getID()}_username">
-                                <span class="component-title">Username:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curNzbProvider.getID()}_username" value="$curNzbProvider.username" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNzbProvider, 'api_key'):
-                        <div class="field-pair">
-                            <label for="${curNzbProvider.getID()}_api_key">
-                                <span class="component-title">API key:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curNzbProvider.getID()}_api_key" value="$curNzbProvider.api_key" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-
-                        #if $hasattr($curNzbProvider, 'enable_daily'):
-                        <div class="field-pair">
-                            <label for="${curNzbProvider.getID()}_enable_daily">
-                                <span class="component-title">Enable daily searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_daily" id="${curNzbProvider.getID()}_enable_daily" #if $curNzbProvider.enable_daily then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform daily searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-                        
-                        #if $hasattr($curNzbProvider, 'enable_backlog'):
-                        <div class="field-pair">
-                            <label for="${curNzbProvider.getID()}_enable_backlog">
-                                <span class="component-title">Enable backlog searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_backlog" id="${curNzbProvider.getID()}_enable_backlog" #if $curNzbProvider.enable_backlog then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform backlog searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNzbProvider, 'search_fallback'):
-                        <div class="field-pair">
-                            <label for="${curNzbProvider.getID()}_search_fallback">
-                                <span class="component-title">Season search fallback</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_search_fallback" id="${curNzbProvider.getID()}_search_fallback" #if $curNzbProvider.search_fallback then "checked=\"checked\"" else ""#/>
-                                    <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curNzbProvider, 'search_mode'):
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Season search mode</span>
-                                <span class="component-desc">
-                                    <p>when searching for complete seasons you can choose to have it look for season packs only, or choose to have it build a complete season from just single episodes.</p>
-                                </span>
-                            </label>
-                            <label> 
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_sponly" value="sponly" #if $curNzbProvider.search_mode=="sponly" then "checked=\"checked\"" else ""# />season packs only.
-                                </span>
-                            </label>
-                            <label> 
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_eponly" value="eponly" #if $curNzbProvider.search_mode=="eponly" then "checked=\"checked\"" else ""# />episodes only.
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                    </div>
-                    #end for
-
-                    #for $curTorrentProvider in [$curProvider for $curProvider in $sickbeard.providers.sortedProviderList() if $curProvider.providerType == $GenericProvider.TORRENT]:
-                    <div class="providerDiv" id="${curTorrentProvider.getID()}Div">
-                        #if $hasattr($curTorrentProvider, 'api_key'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_api_key">
-                                <span class="component-title">Api key:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_api_key" id="${curTorrentProvider.getID()}_api_key" value="$curTorrentProvider.api_key" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'digest'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_digest">
-                                <span class="component-title">Digest:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_digest" id="${curTorrentProvider.getID()}_digest" value="$curTorrentProvider.digest" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'hash'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_hash">
-                                <span class="component-title">Hash:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_hash" id="${curTorrentProvider.getID()}_hash" value="$curTorrentProvider.hash" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'username'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_username">
-                                <span class="component-title">Username:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_username" id="${curTorrentProvider.getID()}_username" value="$curTorrentProvider.username" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'password'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_password">
-                                <span class="component-title">Password:</span>
-                                <span class="component-desc">
-                                    <input type="password" name="${curTorrentProvider.getID()}_password" id="${curTorrentProvider.getID()}_password" value="$curTorrentProvider.password" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'passkey'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_passkey">
-                                <span class="component-title">Passkey:</span>
-                                <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_passkey" id="${curTorrentProvider.getID()}_passkey" value="$curTorrentProvider.passkey" class="form-control input-sm input350" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'ratio'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_ratio">
-                                <span class="component-title" id="${curTorrentProvider.getID()}_ratio_desc">Seed ratio:</span>
-                                <span class="component-desc">
-                                    <input type="number" step="0.1" name="${curTorrentProvider.getID()}_ratio" id="${curTorrentProvider.getID()}_ratio" value="$curTorrentProvider.ratio" class="form-control input-sm input75" />
-                                </span>
-                            </label>
-                            <label>
-                                <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">
-                                    <p>stop transfer when ratio is reached<br>(-1 SickGear default to seed forever, or leave blank for downloader default)</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'minseed'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_minseed">
-                                <span class="component-title" id="${curTorrentProvider.getID()}_minseed_desc">Minimum seeders:</span>
-                                <span class="component-desc">
-                                    <input type="number" name="${curTorrentProvider.getID()}_minseed" id="${curTorrentProvider.getID()}_minseed" value="$curTorrentProvider.minseed" class="form-control input-sm input75" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'minleech'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_minleech">
-                                <span class="component-title" id="${curTorrentProvider.getID()}_minleech_desc">Minimum leechers:</span>
-                                <span class="component-desc">
-                                    <input type="number" name="${curTorrentProvider.getID()}_minleech" id="${curTorrentProvider.getID()}_minleech" value="$curTorrentProvider.minleech" class="form-control input-sm input75" />
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'proxy'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_proxy">
-                                <span class="component-title">Access provider via proxy</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="${curTorrentProvider.getID()}_proxy" id="${curTorrentProvider.getID()}_proxy" #if $curTorrentProvider.proxy.enabled then "checked=\"checked\"" else ""#/>
-                                    <p>to bypass country blocking mechanisms</p>
-                                </span>
-                            </label>
-                        </div>
-
-                        #if $hasattr($curTorrentProvider.proxy, 'url'):
-                        <div class="field-pair content_${curTorrentProvider.getID()}_proxy" id="content_${curTorrentProvider.getID()}_proxy">
-                            <label for="${curTorrentProvider.getID()}_proxy_url">
-                                <span class="component-title">Proxy URL:</span>
-                                <span class="component-desc">
-                                  <select name="${curTorrentProvider.getID()}_proxy_url" id="${curTorrentProvider.getID()}_proxy_url" class="form-control input-sm">
-                                    #for $i in $curTorrentProvider.proxy.urls.keys():
-                                    <option value="$curTorrentProvider.proxy.urls[$i]" #if $curTorrentProvider.proxy.urls[$i] == $curTorrentProvider.proxy.url then "selected=\"selected\"" else ""#>$i</option>
-                                    #end for
-                                    </select>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'confirmed'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_confirmed">
-                                <span class="component-title">Confirmed download</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" #if $curTorrentProvider.confirmed then "checked=\"checked\"" else ""#/>
-                                    <p>only download torrents from trusted or verified uploaders ?</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'freeleech'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_freeleech">
-                                <span class="component-title">Freeleech</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_freeleech" id="${curTorrentProvider.getID()}_freeleech" #if $curTorrentProvider.freeleech then "checked=\"checked\"" else ""#/>
-                                    <p>only download <b>[FreeLeech]</b> torrents.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'enable_daily'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_enable_daily">
-                                <span class="component-title">Enable daily searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_daily" id="${curTorrentProvider.getID()}_enable_daily" #if $curTorrentProvider.enable_daily then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform daily searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-                        
-                        #if $hasattr($curTorrentProvider, 'enable_backlog'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_enable_backlog">
-                                <span class="component-title">Enable backlog searches</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_backlog" id="${curTorrentProvider.getID()}_enable_backlog" #if $curTorrentProvider.enable_backlog then "checked=\"checked\"" else ""#/>
-                                    <p>enable provider to perform backlog searches.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'search_fallback'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_search_fallback">
-                                <span class="component-title">Season search fallback</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_search_fallback" id="${curTorrentProvider.getID()}_search_fallback" #if $curTorrentProvider.search_fallback then "checked=\"checked\"" else ""#/>
-                                    <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'search_mode'):
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Season search mode</span>
-                                <span class="component-desc">
-                                    <p>when searching for complete seasons you can choose to have it look for season packs only, or choose to have it build a complete season from just single episodes.</p>
-                                </span>
-                            </label>
-                            <label> 
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_sponly" value="sponly" #if $curTorrentProvider.search_mode=="sponly" then "checked=\"checked\"" else ""# />season packs only.
-                                </span>
-                            </label>
-                            <label> 
-                                <span class="component-title"></span>
-                                <span class="component-desc">
-                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_eponly" value="eponly" #if $curTorrentProvider.search_mode=="eponly" then "checked=\"checked\"" else ""# />episodes only.
-                                </span>
-                            </label>
-                        </div>
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'options'):
-                        <br>
-                        <input type="hidden" id="tvtorrents_option_string" />
-                        <fieldset>
-                        <legend id="seed_options">Advanced options</legend>
-                        <div class="field-pair">
-                            <label >
-                                <span class="component-title">Seeding ratio(%) goal:</span>
-                                    <input type="text" id="tvtorrents_seed_ratio" class="seed_option form-control input-sm input75" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Seeding time(h) goal:</span>
-                                <input type="text" id="tvtorrents_seed_time" class="seed_option form-control input-sm input75" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Process method:</span>
-                                <select id="tvtorrents_process_method" class="seed_option form-control input-sm" >
-                                    #set $process_method_text = {'': "", 'copy': "Copy", 'move': "Move", 'hardlink': "Hard Link", 'symlink' : "Symbolic Link"}
-                                    #for $curAction in ('', 'copy', 'move', 'hardlink', 'symlink'):
-                                    #set $process_method = ""
-                                        <option class="seed_option" value="$curAction" $process_method>$process_method_text[$curAction]</option>
-                                    #end for
-                                </select>
-                            </label>
-                        </div>
-                        </fieldset>
-                        <br>
-                        #end if
-
-                    </div>
-                    #end for
-
-
-                    <!-- end div for editing providers -->
-
-                    <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
-            
-                    </fieldset>
-                </div><!-- /component-group2 //-->
-
-                #if $sickbeard.USE_NZBS
-                <div id="core-component-group3" class="component-group">
-
-                    <div class="component-group-desc">
-                        <h3>Configure Custom<br />Newznab Providers</h3>
-                        <p>Add and setup or remove custom Newznab providers.</p>
-                    </div>
-
-                    <fieldset class="component-group-list">
-                        <div class="field-pair">
-                            <label for="newznab_string">
-                                <span class="component-title">Select provider:</span>
-                                <span class="component-desc">
-                                    <input type="hidden" name="newznab_string" id="newznab_string" />
-                                    <select id="editANewznabProvider" class="form-control input-sm">
-                                        <option value="addNewznab">-- add new provider --</option>
-                                    </select>
-                                </span>
-                            </label>
-                        </div>
-
-                    <div class="newznabProviderDiv" id="addNewznab">
-                        <div class="field-pair">
-                            <label for="newznab_name">
-                                <span class="component-title">Provider name:</span>
-                                <input type="text" id="newznab_name" class="form-control input-sm input200" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="newznab_url">
-                                <span class="component-title">Site URL:</span>
-                                <input type="text" id="newznab_url" class="form-control input-sm input350" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="newznab_key">
-                                <span class="component-title">API key:</span>
-                                <input type="text" id="newznab_key" class="form-control input-sm input350" />
-                            </label>
-                            <label>
-                                <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">(if not required, type 0)</span>
-                            </label>
-                        </div>
-                        
-                        <div class="field-pair">
-                            <label>
-                                <span class="component-title">Newznab search categories:</span>
-                                <select id="newznab_cap" multiple="multiple" style="min-width:10em;" ></select>
-                                <select id="newznab_cat" multiple="multiple" style="min-width:10em;" ></select>
-                            </label>
-                            <label>
-                                <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">(select your Newznab categories on the left, and click the "update categories" button to use them for searching.) <b>don't forget to to save the form!</b></span>                                
-                            </label>
-                            <label>
-                                <span class="component-title">&nbsp;</span>
-                                <span class="component-desc"><input class="btn" type="button" class="newznab_cat_update" id="newznab_cat_update" value="Update Categories" /></span>                                
-                            </label>
-                        </div>
-                        
-                        <div id="newznab_add_div">
-                            <input class="btn" type="button" class="newznab_save" id="newznab_add" value="Add" />
-                        </div>
-                        <div id="newznab_update_div" style="display: none;">
-                            <input class="btn btn-danger newznab_delete" type="button" class="newznab_delete" id="newznab_delete" value="Delete" />
-                        </div> 
-                    </div>
-
-                    </fieldset>
-                </div><!-- /component-group3 //-->
-                #end if
-
-                #if $sickbeard.USE_TORRENTS:
-
-                <div id="core-component-group4" class="component-group">
-
-                <div class="component-group-desc">
-                    <h3>Configure Custom Torrent Providers</h3>
-                    <p>Add and setup or remove custom RSS providers.</p>
-                </div>
-
-                <fieldset class="component-group-list">
-                    <div class="field-pair">
-                        <label for="torrentrss_string">
-                            <span class="component-title">Select provider:</span>
-                            <span class="component-desc">
-                            <input type="hidden" name="torrentrss_string" id="torrentrss_string" />
-                                <select id="editATorrentRssProvider" class="form-control input-sm">
-                                    <option value="addTorrentRss">-- add new provider --</option>
-                                </select>
-                            </span>
-                        </label>
-                    </div>
-
-                    <div class="torrentRssProviderDiv" id="addTorrentRss">
-                        <div class="field-pair">
-                            <label for="torrentrss_name">
-                                <span class="component-title">Provider name:</span>
-                                <input type="text" id="torrentrss_name" class="form-control input-sm input200" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="torrentrss_url">
-                                <span class="component-title">RSS URL:</span>
-                                <input type="text" id="torrentrss_url" class="form-control input-sm input350" />
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="torrentrss_cookies">
-                                <span class="component-title">Cookies:</span>
-                                <input type="text" id="torrentrss_cookies" class="form-control input-sm input350" />
-                            </label>
-                            <label>
-                                <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">eg. uid=xx;pass=yy</span>
-                            </label>
-                        </div>
-                        
-                        <div id="torrentrss_add_div">
-                            <input type="button" class="btn torrentrss_save" id="torrentrss_add" value="Add" />
-                        </div>
-                        <div id="torrentrss_update_div" style="display: none;">
-                            <input type="button" class="btn btn-danger torrentrss_delete" id="torrentrss_delete" value="Delete" />
-                        </div>
-                    </div>
-                </fieldset>
-            </div><!-- /component-group4 //-->
-            #end if
-
-            <br/><input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
-                
-            </div><!-- /config-components //-->
-
-        </form>
-    </div>
+		</form>
+	</div>
 </div>
 
 <script type="text/javascript" charset="utf-8">
@@ -717,4 +773,4 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
     jQuery('#config-components').tabs();
 //-->
 </script>
-#include $os.path.join($sickbeard.PROG_DIR,"gui/slick/interfaces/default/inc_bottom.tmpl")
+#include $os.path.join($sickbeard.PROG_DIR,'gui/slick/interfaces/default/inc_bottom.tmpl')

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -38,7 +38,7 @@
 
 					<div class="component-group-desc">
 						<h3>Episode Search</h3>
-						<p>How to manage searching with <a href="$sbRoot/config/providers">providers</a>.</p>
+						<p>How to manage searching with <a href="$sbRoot/config/providers/">providers</a>.</p>
 					</div>
 
 					<fieldset class="component-group-list">

--- a/gui/slick/js/config.js
+++ b/gui/slick/js/config.js
@@ -1,27 +1,27 @@
 $(document).ready(function(){
-    $(".enabler").each(function(){
+    $('.enabler').each(function(){
         if (!$(this).prop('checked'))
-            $('#content_'+$(this).attr('id')).hide();
+            $('#content_' + $(this).attr('id')).hide();
     });
 
-    $(".enabler").click(function() {
+    $('.enabler').click(function(){
         if ($(this).prop('checked'))
-            $('#content_'+$(this).attr('id')).fadeIn("fast", "linear");
+            $('#content_' + $(this).attr('id')).fadeIn('fast', 'linear');
         else
-            $('#content_'+$(this).attr('id')).fadeOut("fast", "linear");
+            $('#content_' + $(this).attr('id')).fadeOut('fast', 'linear');
     });
 
-    $(".viewIf").click(function() {
+    $('.viewIf').click(function(){
         if ($(this).prop('checked')) {
-            $('.hide_if_'+$(this).attr('id')).css('display','none');
-            $('.show_if_'+$(this).attr('id')).fadeIn("fast", "linear");
+            $('.hide_if_' + $(this).attr('id')).css('display','none');
+            $('.show_if_' + $(this).attr('id')).fadeIn('fast', 'linear');
         } else {
-            $('.show_if_'+$(this).attr('id')).css('display','none');
-            $('.hide_if_'+$(this).attr('id')).fadeIn("fast", "linear");
+            $('.show_if_' + $(this).attr('id')).css('display','none');
+            $('.hide_if_' + $(this).attr('id')).fadeIn('fast', 'linear');
         }
     });
 
-    $(".datePresets").click(function() {
+    $('.datePresets').click(function(){
         var def = $('#date_presets').val()
         if ($(this).prop('checked') && '%x' == def) {
             def = '%a, %b %d, %Y'
@@ -46,7 +46,7 @@ $(document).ready(function(){
     $('#configForm').ajaxForm({
         beforeSubmit: function(){
             $('.config_submitter').each(function(){
-                $(this).attr("disabled", "disabled");
+                $(this).attr('disabled', 'disabled');
                 $(this).after('<span><img src="' + sbRoot + '/images/loading16' + themeSpinner + '.gif"> Saving...</span>');
                 $(this).hide();
             });
@@ -58,7 +58,7 @@ $(document).ready(function(){
 
     $('#api_key').click(function(){ $('#api_key').select() });
     $("#generate_new_apikey").click(function(){
-        $.get(sbRoot + '/config/general/generateKey', 
+        $.get(sbRoot + '/config/general/generateKey',
             function(data){
                 if (data.error != undefined) {
                     alert(data.error);
@@ -68,8 +68,8 @@ $(document).ready(function(){
         });
     });
 
-    $('#branchCheckout').click(function () {
-        url = sbRoot+'/home/branchCheckout?branch='+$("#branchVersion").val();
+    $('#branchCheckout').click(function(){
+        url = sbRoot + '/home/branchCheckout?branch=' + $('#branchVersion').val();
 		window.location.href = url;
     });
 	
@@ -77,7 +77,7 @@ $(document).ready(function(){
 
 function config_success(){
     $('.config_submitter').each(function(){
-        $(this).removeAttr("disabled");
+        $(this).removeAttr('disabled');
         $(this).next().remove();
         $(this).show();
     });

--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -20,39 +20,39 @@ $(document).ready(function(){
      * @return no return data. Function updateNewznabCaps() is run at callback
      */
     $.fn.getCategories = function (isDefault, selectedProvider) {
-    	
-    	var name = selectedProvider[0];
-    	var url = selectedProvider[1];
-    	var key = selectedProvider[2];
-    	
-    	if (!name)
-    		return;
-    		
-    	if (!url)
-    		return;
-    	
-    	if (!key)
-    		return;
-    	
-    	var params = {url: url, name: name, key: key};
-    	var returnData;
-    	
-    	$.getJSON(sbRoot + '/config/providers/getNewznabCategories', params,
+
+        var name = selectedProvider[0];
+        var url = selectedProvider[1];
+        var key = selectedProvider[2];
+
+        if (!name)
+            return;
+
+        if (!url)
+            return;
+
+        if (!key)
+            return;
+
+        var params = {url: url, name: name, key: key};
+        var returnData;
+
+        $.getJSON(sbRoot + '/config/providers/getNewznabCategories', params,
                 function(data){
                     updateNewznabCaps( data, selectedProvider );
                     console.debug(data.tv_categories);
             });
     }
-    
+
     $.fn.addProvider = function (id, name, url, key, cat, isDefault, showProvider) {
 
-		url = $.trim(url);
-		if (!url)
-			return;
-			
-		if (!/^https?:\/\//i.test(url))
-			url = "http://" + url;
-		
+        url = $.trim(url);
+        if (!url)
+            return;
+
+        if (!/^https?:\/\//i.test(url))
+            url = 'http://' + url;
+
         if (url.match('/$') == null)
             url = url + '/';
 
@@ -64,12 +64,12 @@ $(document).ready(function(){
             $(this).populateNewznabSection();
         }
 
-        if ($('#provider_order_list > #'+id).length == 0 && showProvider != false) {
+        if ($('#provider_order_list > #' + id).length == 0 && showProvider != false) {
             var toAdd = '<li class="ui-state-default" id="' + id + '"> <input type="checkbox" id="enable_' + id + '" class="provider_enabler" CHECKED> <a href="' + anonURL + url + '" class="imgLink" target="_new"><img src="' + sbRoot
                 + '/images/providers/newznab.png" alt="' + name + '" width="16" height="16"></a> ' + name + '</li>'
 
             $('#provider_order_list').append(toAdd);
-            $('#provider_order_list').sortable("refresh");
+            $('#provider_order_list').sortable('refresh');
         }
 
         $(this).makeNewznabProviderString();
@@ -84,12 +84,12 @@ $(document).ready(function(){
         $('#editATorrentRssProvider').addOption(id, name);
         $(this).populateTorrentRssSection();
 
-        if ($('#provider_order_list > #'+id).length == 0) {
+        if ($('#provider_order_list > #' + id).length == 0) {
             var toAdd = '<li class="ui-state-default" id="' + id + '"> <input type="checkbox" id="enable_' + id + '" class="provider_enabler" CHECKED> <a href="' + anonURL + url + '" class="imgLink" target="_new"><img src="' + sbRoot
                 + '/images/providers/torrentrss.png" alt="' + name + '" width="16" height="16"></a> ' + name + '</li>'
 
             $('#provider_order_list').append(toAdd);
-            $('#provider_order_list').sortable("refresh");
+            $('#provider_order_list').sortable('refresh');
         }
 
         $(this).makeTorrentRssProviderString();
@@ -113,7 +113,7 @@ $(document).ready(function(){
         $('#editANewznabProvider').removeOption(id);
         delete newznabProviders[id];
         $(this).populateNewznabSection();
-        $('li').remove('#'+id);
+        $('li').remove('#' + id);
         $(this).makeNewznabProviderString();
 
     }
@@ -129,7 +129,7 @@ $(document).ready(function(){
         $('#editATorrentRssProvider').removeOption(id);
         delete torrentRssProviders[id];
         $(this).populateTorrentRssSection();
-        $('li').remove('#'+id);
+        $('li').remove('#' + id);
         $(this).makeTorrentRssProviderString();
     }
 
@@ -144,115 +144,115 @@ $(document).ready(function(){
             $('#newznab_update_div').hide();
             $('#newznab_cat').attr('disabled','disabled');
             $('#newznab_cap').attr('disabled','disabled');
-            
-            $("#newznab_cat option").each(function() {
-            	$(this).remove();
-            	return;
+
+            $('#newznab_cat option').each(function() {
+                $(this).remove();
+                return;
             });
-            
-            $("#newznab_cap option").each(function() {
-            	$(this).remove();
-            	return;
+
+            $('#newznab_cap option').each(function() {
+                $(this).remove();
+                return;
             });
-            
+
         } else {
             var data = newznabProviders[selectedProvider][1];
             var isDefault = newznabProviders[selectedProvider][0];
             $('#newznab_add_div').hide();
             $('#newznab_update_div').show();
-            $('#newznab_cat').removeAttr("disabled");
-            $('#newznab_cap').removeAttr("disabled");
+            $('#newznab_cat').removeAttr('disabled');
+            $('#newznab_cap').removeAttr('disabled');
         }
 
         $('#newznab_name').val(data[0]);
         $('#newznab_url').val(data[1]);
         $('#newznab_key').val(data[2]);
-        
+
         //Check if not already array
         if (typeof data[3] === 'string') {
-        	rrcat = data[3].split(",")
-        } 
-        else {
-        	rrcat = data[3];
+            rrcat = data[3].split(',')
         }
-        
+        else {
+            rrcat = data[3];
+        }
+
         // Update the category select box (on the right)
         var newCatOptions = [];
         if (rrcat) {
-        	rrcat.forEach(function (cat) {
-        		newCatOptions.push({text : cat, value : cat});
+            rrcat.forEach(function (cat) {
+                newCatOptions.push({text : cat, value : cat});
             });
-        	$("#newznab_cat").replaceOptions(newCatOptions);
+            $('#newznab_cat').replaceOptions(newCatOptions);
         };
-        
+
         if (selectedProvider == 'addNewznab') {
-            $('#newznab_name').removeAttr("disabled");
-            $('#newznab_url').removeAttr("disabled");
+            $('#newznab_name').removeAttr('disabled');
+            $('#newznab_url').removeAttr('disabled');
         } else {
 
-            $('#newznab_name').attr("disabled", "disabled");
+            $('#newznab_name').attr('disabled', 'disabled');
 
             if (isDefault) {
-                $('#newznab_url').attr("disabled", "disabled");
-                $('#newznab_delete').attr("disabled", "disabled");
+                $('#newznab_url').attr('disabled', 'disabled');
+                $('#newznab_delete').attr('disabled', 'disabled');
             } else {
-                $('#newznab_url').removeAttr("disabled");
-                $('#newznab_delete').removeAttr("disabled");
-                
+                $('#newznab_url').removeAttr('disabled');
+                $('#newznab_delete').removeAttr('disabled');
+
                 //Get Categories Capabilities
                 if (data[0] && data[1] && data[2] && !ifExists($.fn.newznabProvidersCapabilities, data[0])) {
-                	$(this).getCategories(isDefault, data);
+                    $(this).getCategories(isDefault, data);
                 }
                 else {
-                	updateNewznabCaps( null, data );
+                    updateNewznabCaps( null, data );
                 }
             }
         }
     }
 
     ifExists = function(loopThroughArray, searchFor) {
-    	var found = false;
-    	
-    	loopThroughArray.forEach(function(rootObject) { 
-    		if (rootObject.name == searchFor) {
-    			found = true;
-    		}
-    		console.log(rootObject.name + " while searching for: "+  searchFor);
-    	});
-    	return found;
+        var found = false;
+
+        loopThroughArray.forEach(function(rootObject) {
+            if (rootObject.name == searchFor) {
+                found = true;
+            }
+            console.log(rootObject.name + ' while searching for: ' + searchFor);
+        });
+        return found;
     };
-    
+
     /**
-     * Updates the Global array $.fn.newznabProvidersCapabilities with a combination of newznab prov name 
+     * Updates the Global array $.fn.newznabProvidersCapabilities with a combination of newznab prov name
      * and category capabilities. Return
      * @param {Array} newzNabCaps, is the returned object with newzNabprod Name and Capabilities.
      * @param {Array} selectedProvider
      * @return no return data. The multiselect input $("#newznab_cap") is updated, as a result.
      */
     updateNewznabCaps = function( newzNabCaps, selectedProvider ) {
-    	
-    	if (newzNabCaps && !ifExists($.fn.newznabProvidersCapabilities, selectedProvider[0])) {
-    		$.fn.newznabProvidersCapabilities.push({'name' : selectedProvider[0], 'categories' : newzNabCaps.tv_categories});
-    	}
-    	
-    	//Loop through the array and if currently selected newznab provider name matches one in the array, use it to
+
+        if (newzNabCaps && !ifExists($.fn.newznabProvidersCapabilities, selectedProvider[0])) {
+            $.fn.newznabProvidersCapabilities.push({'name' : selectedProvider[0], 'categories' : newzNabCaps.tv_categories});
+        }
+
+        //Loop through the array and if currently selected newznab provider name matches one in the array, use it to
         //update the capabilities select box (on the left).
         if (selectedProvider[0]) {
-        	$.fn.newznabProvidersCapabilities.forEach(function(newzNabCap) {
-            	                    	
-            	if (newzNabCap.name && newzNabCap.name == selectedProvider[0] && newzNabCap.categories instanceof Array) {
-            			var newCapOptions = [];
-            			newzNabCap.categories.forEach(function(category_set) {
-        					if (category_set.id && category_set.name) { 
-        						newCapOptions.push({value : category_set.id, text : category_set.name + "(" + category_set.id + ")"});
-        					};
-        				});
-        				$("#newznab_cap").replaceOptions(newCapOptions);
-            	}
+            $.fn.newznabProvidersCapabilities.forEach(function(newzNabCap) {
+
+                if (newzNabCap.name && newzNabCap.name == selectedProvider[0] && newzNabCap.categories instanceof Array) {
+                        var newCapOptions = [];
+                        newzNabCap.categories.forEach(function(category_set) {
+                            if (category_set.id && category_set.name) {
+                                newCapOptions.push({value : category_set.id, text : category_set.name + '(' + category_set.id + ')'});
+                            };
+                        });
+                        $('#newznab_cap').replaceOptions(newCapOptions);
+                }
             });
         };
     }
-    
+
     $.fn.makeNewznabProviderString = function() {
 
         var provStrings = new Array();
@@ -284,14 +284,14 @@ $(document).ready(function(){
         $('#torrentrss_cookies').val(data[2]);
 
         if (selectedProvider == 'addTorrentRss') {
-            $('#torrentrss_name').removeAttr("disabled");
-            $('#torrentrss_url').removeAttr("disabled");
-            $('#torrentrss_cookies').removeAttr("disabled");
+            $('#torrentrss_name').removeAttr('disabled');
+            $('#torrentrss_url').removeAttr('disabled');
+            $('#torrentrss_cookies').removeAttr('disabled');
         } else {
-            $('#torrentrss_name').attr("disabled", "disabled");
-            $('#torrentrss_url').removeAttr("disabled");
-            $('#torrentrss_cookies').removeAttr("disabled");
-            $('#torrentrss_delete').removeAttr("disabled");
+            $('#torrentrss_name').attr('disabled', 'disabled');
+            $('#torrentrss_url').removeAttr('disabled');
+            $('#torrentrss_cookies').removeAttr('disabled');
+            $('#torrentrss_delete').removeAttr('disabled');
         }
 
     }
@@ -309,26 +309,26 @@ $(document).ready(function(){
 
 
     $.fn.refreshProviderList = function() {
-        var idArr = $("#provider_order_list").sortable('toArray');
+        var idArr = $('#provider_order_list').sortable('toArray');
         var finalArr = new Array();
         $.each(idArr, function(key, val) {
-            var checked = + $('#enable_'+val).prop('checked') ? '1' : '0';
+            var checked = + $('#enable_' + val).prop('checked') ? '1' : '0';
             finalArr.push(val + ':' + checked);
         });
 
-            $("#provider_order").val(finalArr.join(' '));
+            $('#provider_order').val(finalArr.join(' '));
     }
 
     var newznabProviders = new Array();
     var torrentRssProviders = new Array();
-    
+
     $(this).on('change', '.newznab_key', function(){
 
         var provider_id = $(this).attr('id');
         provider_id = provider_id.substring(0, provider_id.length-'_hash'.length);
 
-        var url = $('#'+provider_id+'_url').val();
-        var cat = $('#'+provider_id+'_cat').val();
+        var url = $('#' + provider_id + '_url').val();
+        var cat = $('#' + provider_id + '_cat').val();
         var key = $(this).val();
 
         $(this).updateProvider(provider_id, url, key, cat);
@@ -339,16 +339,16 @@ $(document).ready(function(){
 
         var selectedProvider = $('#editANewznabProvider :selected').val();
 
-    if (selectedProvider == "addNewznab")
+    if (selectedProvider == 'addNewznab')
       return;
-    
+
         var url = $('#newznab_url').val();
         var key = $('#newznab_key').val();
 
         var cat = $('#newznab_cat option').map(function(i, opt) {
-        	  return $(opt).text();
-        	}).toArray().join(',');
-        
+              return $(opt).text();
+            }).toArray().join(',');
+
         $(this).updateProvider(selectedProvider, url, key, cat);
 
     });
@@ -357,7 +357,7 @@ $(document).ready(function(){
 
         var selectedProvider = $('#editATorrentRssProvider :selected').val();
 
-    if (selectedProvider == "addTorrentRss")
+    if (selectedProvider == 'addTorrentRss')
       return;
 
         var url = $('#torrentrss_url').val();
@@ -385,46 +385,46 @@ $(document).ready(function(){
 
     $(this).on('click', '#newznab_cat_update', function(){
         console.debug('Clicked Button');
-        
+
         //Maybe check if there is anything selected?
-        $("#newznab_cat option").each(function() {
-        	$(this).remove();
-        	return;
+        $('#newznab_cat option').each(function() {
+            $(this).remove();
+            return;
         });
-        
+
         var newOptions = [];
-        
-        // When the update botton is clicked, loop through the capabilities list 
+
+        // When the update botton is clicked, loop through the capabilities list
         // and copy the selected category id's to the category list on the right.
-        $("#newznab_cap option").each(function(){
+        $('#newznab_cap option').each(function(){
             if($(this).attr('selected') == 'selected')
             {
-            	var selected_cat = $(this).val();
-            	console.debug(selected_cat);
-            	newOptions.push({text: selected_cat, value: selected_cat})
+                var selected_cat = $(this).val();
+                console.debug(selected_cat);
+                newOptions.push({text: selected_cat, value: selected_cat})
              };
         });
-        
-        $("#newznab_cat").replaceOptions(newOptions);
-        
-        var selectedProvider = $('#editANewznabProvider :selected').val();
-        if (selectedProvider == "addNewznab")
-            return;
-          
-	    var url = $('#newznab_url').val();
-	    var key = $('#newznab_key').val();
 
-	    var cat = $('#newznab_cat option').map(function(i, opt) {
-      	  return $(opt).text();
-      	}).toArray().join(',');
-	    
-	    $("#newznab_cat option:not([value])").remove();
-	    
+        $('#newznab_cat').replaceOptions(newOptions);
+
+        var selectedProvider = $('#editANewznabProvider :selected').val();
+        if (selectedProvider == 'addNewznab')
+            return;
+
+        var url = $('#newznab_url').val();
+        var key = $('#newznab_key').val();
+
+        var cat = $('#newznab_cat option').map(function(i, opt) {
+          return $(opt).text();
+        }).toArray().join(',');
+
+        $('#newznab_cat option:not([value])').remove();
+
         $(this).updateProvider(selectedProvider, url, key, cat);
 
     });
-    
-    
+
+
     $('#newznab_add').click(function(){
 
         var selectedProvider = $('#editANewznabProvider :selected').val();
@@ -433,19 +433,19 @@ $(document).ready(function(){
         var url = $.trim($('#newznab_url').val());
         var key = $.trim($('#newznab_key').val());
         //var cat = $.trim($('#newznab_cat').val());
-        
+
         var cat = $.trim($('#newznab_cat option').map(function(i, opt) {
-        	  return $(opt).text();}).toArray().join(','));
-        
-        
+              return $(opt).text();}).toArray().join(','));
+
+
         if (!name)
-        	return;
+            return;
 
         if (!url)
-        	return;        	
+            return;
 
         if (!key)
-        	return;
+            return;
 
         var params = {name: name};
 
@@ -496,12 +496,12 @@ $(document).ready(function(){
     });
 
 
-    $(this).on('change', "[class='providerDiv_tip'] input", function(){
-        $('div .providerDiv ' + "[name=" + $(this).attr('name') + "]").replaceWith($(this).clone());
-        $('div .providerDiv ' + "[newznab_name=" + $(this).attr('id') + "]").replaceWith($(this).clone());
+    $(this).on('change', '[class="providerDiv_tip"] input', function(){
+        $('div .providerDiv ' + '[name=' + $(this).attr('name') + ']').replaceWith($(this).clone());
+        $('div .providerDiv ' + '[newznab_name=' + $(this).attr('id') + ']').replaceWith($(this).clone());
     });
 
-    $(this).on('change', "[class='providerDiv_tip'] select", function(){
+    $(this).on('change', '[class="providerDiv_tip"] select', function(){
 
     $(this).find('option').each( function() {
       if ($(this).is(':selected')) {
@@ -511,34 +511,34 @@ $(document).ready(function(){
       }
     });
 
-    $('div .providerDiv ' + "[name=" + $(this).attr('name') + "]").empty().replaceWith($(this).clone())});
+    $('div .providerDiv ' + '[name=' + $(this).attr('name') + ']').empty().replaceWith($(this).clone())});
 
     $(this).on('change', '.enabler', function(){
       if ($(this).is(':checked')) {
-          $('.content_'+$(this).attr('id')).each( function() {
+          $('.content_' + $(this).attr('id')).each( function() {
               $(this).show()
           })
       } else {
-            $('.content_'+$(this).attr('id')).each( function() {
+            $('.content_' + $(this).attr('id')).each( function() {
                 $(this).hide()
             })
       }
     });
 
-    $(".enabler").each(function(){
+    $('.enabler').each(function(){
         if (!$(this).is(':checked')) {
-          $('.content_'+$(this).attr('id')).hide();
+          $('.content_' + $(this).attr('id')).hide();
         } else {
-          $('.content_'+$(this).attr('id')).show();
+          $('.content_' + $(this).attr('id')).show();
       }
     });
 
     $.fn.makeTorrentOptionString = function(provider_id) {
 
-	    var seed_ratio  = $('.providerDiv_tip #'+provider_id+'_seed_ratio').prop('value');
-	    var seed_time   = $('.providerDiv_tip #'+provider_id+'_seed_time').prop('value');
-	    var process_met = $('.providerDiv_tip #'+provider_id+'_process_method').prop('value');
-		var option_string = $('.providerDiv_tip #'+provider_id+'_option_string');	
+        var seed_ratio = $('.providerDiv_tip #' + provider_id + '_seed_ratio').prop('value');
+        var seed_time = $('.providerDiv_tip #' + provider_id + '_seed_time').prop('value');
+        var process_met = $('.providerDiv_tip #' + provider_id + '_process_method').prop('value');
+        var option_string = $('.providerDiv_tip #' + provider_id + '_option_string');
 
         option_string.val([seed_ratio, seed_time, process_met].join('|'))
 
@@ -548,11 +548,11 @@ $(document).ready(function(){
 
         var provider_id = $(this).attr('id').split('_')[0];
 
-		$(this).makeTorrentOptionString(provider_id);
+        $(this).makeTorrentOptionString(provider_id);
 
     });
-    
-    
+
+
     $.fn.replaceOptions = function(options) {
         var self, $option;
 
@@ -560,8 +560,8 @@ $(document).ready(function(){
         self = this;
 
         $.each(options, function(index, option) {
-          $option = $("<option></option>")
-            .attr("value", option.value)
+          $option = $('<option></option>')
+            .attr('value', option.value)
             .text(option.text);
           self.append($option);
         });
@@ -569,18 +569,18 @@ $(document).ready(function(){
 
     // initialization stuff
 
-    
+
     $.fn.newznabProvidersCapabilities = [];
 
     $(this).showHideProviders();
 
-    $("#provider_order_list").sortable({
+    $('#provider_order_list').sortable({
         placeholder: 'ui-state-highlight',
         update: function (event, ui) {
             $(this).refreshProviderList();
         }
     });
 
-    $("#provider_order_list").disableSelection();
+    $('#provider_order_list').disableSelection();
 
 });


### PR DESCRIPTION
Change Config/Search Providers texts and descriptions.
Fix display when no providers are visible on Config/Search Providers.
Fix failing "Search Settings" link that is shown on Config/Search Providers when Torrents Search is not enabled under that Config/Search Settings/Torrent Search tab.
Fix failing "Providers" link on Config/Search Settings/Episode Search tab.
Change case of labels in General Config/Interface/Timezone.
Split enabled from not enabled providers in the Configure Provider drop down on the Providers Options tab.
