### PR TITLE
Change SQL for Coming Episodes Page to include +/- 1 day, ...

### DIFF
--- a/gui/slick/interfaces/default/comingEpisodes.tmpl
+++ b/gui/slick/interfaces/default/comingEpisodes.tmpl
@@ -375,6 +375,7 @@
             #set $today_header = True
         #end if
         #if $runtime:
+            #set $cur_ep_enddate = $cur_result['localtime'] + datetime.timedelta(minutes = $runtime)
             #if $cur_ep_enddate < $today:
                 #set $show_div = 'ep_listing listing-overdue'
             #elif $cur_ep_airdate >= $next_week.date():

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -351,11 +351,12 @@ class MainHandler(RequestHandler):
 
     def comingEpisodes(self, layout="None"):
 
-        today1 = datetime.date.today()
+        today1 = datetime.date.today() - datetime.timedelta(days=1)
         today = today1.toordinal()
+        tommorrow = (datetime.date.today() + datetime.timedelta(days=1))
         next_week1 = (datetime.date.today() + datetime.timedelta(days=7))
-        next_week = next_week1.toordinal()
-        recently = (datetime.date.today() - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
+        next_week = (next_week1 + datetime.timedelta(days=1)).toordinal()
+        recently = (today1 - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
 
         done_show_list = []
         qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]
@@ -378,7 +379,7 @@ class MainHandler(RequestHandler):
 
         more_sql_results = myDB.select(
             "SELECT *, tv_shows.status as show_status FROM tv_episodes, tv_shows WHERE season != 0 AND tv_shows.indexer_id = tv_episodes.showid AND airdate < ? AND airdate >= ? AND tv_episodes.status = ? AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, recently, WANTED] + qualList)
+                ['?'] * len(qualList)) + ")", [tommorrow, recently, WANTED] + qualList)
         sql_results += more_sql_results
 
         # sort by localtime


### PR DESCRIPTION
for timezone corrections, since the db has dates/times without timezone correction we need to include for the current week the time from yesterday until 1 week + 1 day. Also we need to include tomorrow for the wanted episode search, since the db episode date could be tomorrow for a show in a different timezone, that is already the past in the users timezone. Same for the missed episode range, here we have to take an extra day in the past (to compensate timezone differences).

All this has to be done regardless of the users displaying setting (local or network), since this setting doesn't change the fact when the episode really airs.

I also fixed a bug that $cur_ep_endate variable on the Coming Episodes wasn't set for every episode resulting in all episodes in banner view had the same background color even if some already aired and some still air later that day.
