### PR TITLE
Fix Coming Eps Page to include shows +/- 1 day for time zone corrections.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 0.4.0 (2014-11-23 08:44:00 UTC)
+### 0.4.0 (2014-11-24 00:55:00 UTC)
 
 * Change footer stats to not add newlines when copy/pasting from them
 * Remove redundant references from Config/Help & Info
@@ -48,6 +48,7 @@
 * Fix Add Trending Shows "Not In library" now filters tvrage added shows
 * Add a hover over text "In library" on Add Trending Shows to display tv database show was added from
 * Fix reduces time API endpoint Shows takes to return results
+* Fix Coming Eps Page to include shows +/- 1 day for time zone corrections
 
 ### 0.3.1 (2014-11-19 16:40:00 UTC)
 

--- a/gui/slick/interfaces/default/comingEpisodes.tmpl
+++ b/gui/slick/interfaces/default/comingEpisodes.tmpl
@@ -375,6 +375,7 @@
             #set $today_header = True
         #end if
         #if $runtime:
+            #set $cur_ep_enddate = $cur_result['localtime'] + datetime.timedelta(minutes = $runtime)
             #if $cur_ep_enddate < $today:
                 #set $show_div = 'ep_listing listing-overdue'
             #elif $cur_ep_airdate >= $next_week.date():

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -351,11 +351,12 @@ class MainHandler(RequestHandler):
 
     def comingEpisodes(self, layout="None"):
 
-        today1 = datetime.date.today()
+        today1 = datetime.date.today() - datetime.timedelta(days=1)
         today = today1.toordinal()
+        tommorrow = (datetime.date.today() + datetime.timedelta(days=1))
         next_week1 = (datetime.date.today() + datetime.timedelta(days=7))
-        next_week = next_week1.toordinal()
-        recently = (datetime.date.today() - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
+        next_week = (next_week1 + datetime.timedelta(days=1)).toordinal()
+        recently = (today1 - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
 
         done_show_list = []
         qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]
@@ -378,8 +379,10 @@ class MainHandler(RequestHandler):
 
         more_sql_results = myDB.select(
             "SELECT *, tv_shows.status as show_status FROM tv_episodes, tv_shows WHERE season != 0 AND tv_shows.indexer_id = tv_episodes.showid AND airdate < ? AND airdate >= ? AND tv_episodes.status = ? AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, recently, WANTED] + qualList)
+                ['?'] * len(qualList)) + ")", [tommorrow, recently, WANTED] + qualList)
         sql_results += more_sql_results
+
+        sql_results = list(set(sql_results))
 
         # sort by localtime
         sorts = {


### PR DESCRIPTION
More detail...
Episodes airing in a different time zone to the users own can be missing on the Coming Episodes Page. For today, the current day next week, and the last day in the missing episode range; these 3 days (+/- 1 day) can be missing episodes from the display if they air on a different day in their time zone compared to the users current day.

All episodes in the banner layout for today may display as red or green background even if not aired/missing yet because of their airing time. The background colour of the first episode of today in banner view would be shown for all episodes today in this view, since the variable for the episode ending which determines the background colour was only set for the first episode after the today's day header.

Technical detail...
Fix banner view: cur_ep_enddate wasn't set for every episode.
Remove duplicates from SQL result.
