### PR TITLE
Remove redundant Coming Eps template code used in the old UI.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Add ability to auto focus Search Show box on Home page and control this option via General Config/Interface
 * Add TVRage network name standardization
 * Change some provider images. Add a few new images
+* Remove redundant Coming Eps template code used in the old UI
 
 [develop changelog]
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -425,25 +425,6 @@ class MainHandler(RequestHandler):
         sql_results.sort(sorts[sickbeard.COMING_EPS_SORT])
 
         t = PageTemplate(headers=self.request.headers, file="comingEpisodes.tmpl")
-        # paused_item = { 'title': '', 'path': 'toggleComingEpsDisplayPaused' }
-        # paused_item['title'] = 'Hide Paused' if sickbeard.COMING_EPS_DISPLAY_PAUSED else 'Show Paused'
-        paused_item = {'title': 'View Paused:', 'path': {'': ''}}
-        paused_item['path'] = {'Hide': 'toggleComingEpsDisplayPaused'} if sickbeard.COMING_EPS_DISPLAY_PAUSED else {
-            'Show': 'toggleComingEpsDisplayPaused'}
-        t.submenu = [
-            {'title': 'Sort by:', 'path': {'Date': 'setComingEpsSort/?sort=date',
-                                           'Show': 'setComingEpsSort/?sort=show',
-                                           'Network': 'setComingEpsSort/?sort=network',
-            }},
-
-            {'title': 'Layout:', 'path': {'Banner': 'setComingEpsLayout/?layout=banner',
-                                          'Poster': 'setComingEpsLayout/?layout=poster',
-                                          'List': 'setComingEpsLayout/?layout=list',
-                                          'Calendar': 'setComingEpsLayout/?layout=calendar',
-            }},
-            paused_item,
-        ]
-
         t.next_week = datetime.datetime.combine(next_week_dt, datetime.time(tzinfo=network_timezones.sb_timezone))
         t.today = datetime.datetime.now(network_timezones.sb_timezone)
         t.sql_results = sql_results


### PR DESCRIPTION
The submenu variable is no longer used on the Coming Eps page.
