### PR TITLE
Fix article removal for sorting on Display Show, and API pages.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 * Change KickassTorrents provider URLs
 * Fix missing Content-Type headers for posters and banners
 * Remove config Backup & Restore
+* Fix article removal for sorting on Display Show, and API pages
 
 [develop changelog]
 * Add TVRage network name standardization

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1429,4 +1429,4 @@ def get_size(start_path='.'):
     return total_size
 
 def remove_article(text=''):
-    return re.sub(r'(?i)/^(?:(?:A(?!\s+to)n?)|The)\s(\w)', r'\1', text)
+    return re.sub(r'(?i)^(?:(?:A(?!\s+to)n?)|The)\s(\w)', r'\1', text)


### PR DESCRIPTION
Remove Javascript regex boundary from Python regex.
