### PR TITLE
Add a link from the footer number of snatched to episode snatched overvi...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,11 @@
 * Change Display Show next/previous when show list is not split to loop around
 * Fix SQL statements that have dynamic table names to use proper syntax
 * Fix port checking code preventing startup directly after a SG restart
+* Add a link from the footer number of snatched to episode snatched overview page. The link to the 
+  Episode Overview page is available on all pages except on the Episode Overview page
+* Change the default state for all check boxes on the Episode Overview page to not checked
+* Add validation to Go button to ensure at least one item is checked on Episode Overview page
+* Add highlight to current status text in header on Episode Overview page
 
 [develop changelog]
 * Add TVRage network name standardization

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -38,9 +38,30 @@
     #set $ep_downloaded = 0
     #set $ep_total = 0
 #end if
+#try
+    #set $localRoot = $sbRoot
+#except NotFound
+    #set $localRoot = ''
+#end try
+#try
+    #set $localheader = $header
+#except NotFound
+    #set $localheader = ''
+#end try
 
 		<span class="footerhighlight">$shows_total</span> shows (<span class="footerhighlight">$shows_active</span> active)
-		| <span class="footerhighlight"><%= ep_downloaded %></span><%= ('', ' (<span class="footerhighlight">+%s</span> snatched)' % str(ep_snatched))[ep_snatched > 0] %>&nbsp;/&nbsp;<span class="footerhighlight">$ep_total</span> episodes downloaded
+		| <span class="footerhighlight"><%= ep_downloaded %></span>
+			<%= (
+				'',\
+				' (<span class="footerhighlight">+%s</span> snatched)' % \
+					(
+					str(ep_snatched),
+                    '<a href="%s/manage/episodeStatuses?whichStatus=2" title="View overview of snatched episodes">%s</a>' % \
+                        (localRoot, str(ep_snatched))
+                    )['Episode Overview' != localheader]
+				)[0 < ep_snatched]
+			%>
+			&nbsp;/&nbsp;<span class="footerhighlight">$ep_total</span> episodes downloaded
 		| daily search: <span class="footerhighlight"><%= str(sickbeard.dailySearchScheduler.timeLeft()).split('.')[0] %></span>
 		| backlog search: <span class="footerhighlight">$sbdatetime.sbdatetime.sbfdate($sickbeard.backlogSearchScheduler.nextRun())</span>
 

--- a/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
+++ b/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
@@ -40,7 +40,7 @@ Manage episodes with status <select name="whichStatus" class="form-control form-
 <form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
 <input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus" />
 
-<h2>Shows containing $common.statusStrings[$int($whichStatus)] episodes</h2>
+<h2><span class="grey-text">Shows containing</span> $common.statusStrings[$int($whichStatus)] <span class="grey-text">episodes</span></h2>
 
 <br />
 
@@ -65,7 +65,7 @@ $statusList.append($common.FAILED)
 <option value="$curStatus">$common.statusStrings[$curStatus]</option>
 #end for
 </select>
-<input class="btn btn-inline" type="submit" value="Go" />
+<input class="btn btn-inline go" type="submit" value="Go" />
 
 <div>
 	<button type="button" class="btn btn-xs selectAllShows">Select all</a></button> 
@@ -76,7 +76,7 @@ $statusList.append($common.FAILED)
 <table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0">
 #for $cur_indexer_id in $sorted_show_ids:
  <tr id="$cur_indexer_id">
-  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_indexer_id" name="$cur_indexer_id-all" checked="checked" /></th>
+  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_indexer_id" name="$cur_indexer_id-all" /></th>
   <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_indexer_id">$show_names[$cur_indexer_id]</a> ($ep_counts[$cur_indexer_id]) <input type="button" class="pull-right get_more_eps btn" id="$cur_indexer_id" value="Expand" /></th>
  </tr>
 #end for

--- a/gui/slick/js/manageEpisodeStatuses.js
+++ b/gui/slick/js/manageEpisodeStatuses.js
@@ -1,34 +1,40 @@
 $(document).ready(function() { 
 
     function make_row(indexer_id, season, episode, name, checked) {
-        if (checked)
-            var checked = ' checked';
-        else
-            var checked = '';
-        
-        var row_class = $('#row_class').val();
-        
-        var row = '';
-        row += ' <tr class="'+row_class+'">';
-        row += '  <td class="tableleft" align="center"><input type="checkbox" class="'+indexer_id+'-epcheck" name="'+indexer_id+'-'+season+'x'+episode+'"'+checked+'></td>';
-        row += '  <td>'+season+'x'+episode+'</td>';
-        row += '  <td class="tableright" style="width: 100%">'+name+'</td>';
-        row += ' </tr>'
-        
-        return row;
+        var checkedbox = (checked ? ' checked' : ''),
+            row_class = $('#row_class').val();
+
+        return ' <tr class="' + row_class + '">'
+            + '  <td class="tableleft" align="center">'
+                + '<input type="checkbox"'
+                    + ' class="' + indexer_id + '-epcheck"'
+                    + ' name="' + indexer_id + '-' + season + 'x' + episode + '"'
+                    + checkedbox+'></td>'
+            + '  <td>' + season + 'x' + episode + '</td>'
+            + '  <td class="tableright" style="width: 100%">' + name + '</td>'
+            + ' </tr>';
     }
+
+    $('.go').click(function() {
+        var selected;
+
+        if (selected = (0 === $('input[class*="-epcheck"]:checked').length))
+            alert('Please select at least one episode');
+
+        return !selected
+    });
 
     $('.allCheck').click(function(){
         var indexer_id = $(this).attr('id').split('-')[1];
-        $('.'+indexer_id+'-epcheck').prop('checked', $(this).prop('checked'));
+        $('.' + indexer_id + '-epcheck').prop('checked', $(this).prop('checked'));
     });
 
     $('.get_more_eps').click(function(){
         var cur_indexer_id = $(this).attr('id');
-        var checked = $('#allCheck-'+cur_indexer_id).prop('checked');
-        var last_row = $('tr#'+cur_indexer_id);
+        var checked = $('#allCheck-' + cur_indexer_id).prop('checked');
+        var last_row = $('tr#' + cur_indexer_id);
         
-        $.getJSON(sbRoot+'/manage/showEpisodeStatuses',
+        $.getJSON(sbRoot + '/manage/showEpisodeStatuses',
                   {
                    indexer_id: cur_indexer_id,
                    whichStatus: $('#oldStatus').val()


### PR DESCRIPTION
...ew page.

The link to the Episode Overview page is available on all pages except on the Episode Overview page.
Change the default state for all check boxes on the Episode Overview page to not checked.
Add validation to Go button to ensure at least one item is checked on Episode Overview page.
Add highlight to current status text in header on Episode Overview page.
Cleanup manageEpisodeStatuses Javascript.
