### PR TITLE
Rationalize Deluge labels and options

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -421,6 +421,7 @@
 										<div class="clear-left">
 											<p id="host_desc_torrent">URL to your torrent client (e.g. http://localhost:8000/)</p>
 											<p id="host_desc_rtorrent" style="display:none"><b>Note:</b> <i>rTorrent</i> client URLs use e.g. scgi://localhost:5000/</p>
+											<p id="host_desc_deluge" style="display:none">URL to your Deluge WebUI (e.g. http://localhost:8000/)</p>
 										</div>
 									</span>
 								</label>
@@ -436,7 +437,7 @@
 								</label>
 							</div>
 
-							<div class="field-pair">
+							<div class="field-pair" id="torrent_username_option">
 								<label>
 									<span class="component-title" id="username_title">Client username</span>
 									<span class="component-desc">

--- a/gui/slick/js/configSearch.js
+++ b/gui/slick/js/configSearch.js
@@ -62,7 +62,9 @@ $(document).ready(function(){
 
             $(label_warning_deluge).hide();
             $(host_desc_rtorrent).hide();
+            $(host_desc_deluge).hide();
             $(host_desc_torrent).show();
+            $(torrent_username_option).show();
             $(torrent_verify_cert_option).hide();
             $(torrent_path_option).show();
             $(torrent_path_option).find('.fileBrowser').show();
@@ -86,6 +88,9 @@ $(document).ready(function(){
                 client = 'Deluge';
                 $(torrent_verify_cert_option).show();
                 $(label_warning_deluge).show();
+                $(host_desc_torrent).hide();
+                $(host_desc_deluge).show();
+                $(torrent_username_option).hide();
                 //$('#directory_title').text(client + directory);
             } else if ('download_station' == selectedProvider){
                 client = 'Synology DS';


### PR DESCRIPTION
Deluge uses WebUI to connect to deluge daemon, lets make sure that the
user knows what to enter. Also the WebUI doesn't use a username at all,
so we can hide that field so that the user doesn't get confused
