### PR TITLE
Change recent and backlog search timing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 * Fix slow database operations (port from midgetspy/sickbeard)
 * Add TVRage network name standardization
+* Remove recent and backlog search at start up options from GUI
+* Change recent and backlog search at start up default value to false
+* Change recent search to occur 5 minutes after start up
+* Change backlog search to occur 10 minutes after start up
+* Change UI footer to display time left until a backlog search
 
 [develop changelog]
 

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -138,26 +138,6 @@
 							</label>
 						</div>
 
-						<div class="field-pair">
-							<label for="recentsearch_startup">
-								<span class="component-title">Recent search on startup</span>
-								<span class="component-desc">
-									<input type="checkbox" name="recentsearch_startup" id="recentsearch_startup" <%= html_checked if sickbeard.RECENTSEARCH_STARTUP == True else '' %>/>
-									<p>start recent search on startup of SickGear</p>
-								</span>
-							</label>
-						</div>
-
-						<div class="field-pair">
-							<label for="backlog_startup">
-								<span class="component-title">Run backlog on startup</span>
-								<span class="component-desc">
-									<input type="checkbox" name="backlog_startup" id="backlog_startup" <%= html_checked if sickbeard.BACKLOG_STARTUP == True else '' %>/>
-									<p>start processing backlogged episodes on startup of SickGear</p>
-								</span>
-							</label>
-						</div>
-
 						<input type="submit" class="btn config_submitter" value="Save Changes" />
 
 					</fieldset>

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -63,7 +63,7 @@
 			%>
 			&nbsp;/&nbsp;<span class="footerhighlight">$ep_total</span> episodes downloaded
 		| recent search: <span class="footerhighlight"><%= str(sickbeard.recentSearchScheduler.timeLeft()).split('.')[0] %></span>
-		| backlog search: <span class="footerhighlight">$sbdatetime.sbdatetime.sbfdate($sickbeard.backlogSearchScheduler.nextRun())</span>
+		| backlog search: <span class="footerhighlight"><%= str(sickbeard.backlogSearchScheduler.timeLeft()).split('.')[0] %></span>
 
 	</div>
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -58,7 +58,7 @@ CFG = None
 CONFIG_FILE = None
 
 # This is the version of the config we EXPECT to find
-CONFIG_VERSION = 7
+CONFIG_VERSION = 8
 
 # Default encryption version (0 for None)
 ENCRYPTION_VERSION = 0
@@ -674,8 +674,8 @@ def initialize(consoleLogging=True):
 
         ALLOW_HIGH_PRIORITY = bool(check_setting_int(CFG, 'General', 'allow_high_priority', 1))
 
-        RECENTSEARCH_STARTUP = bool(check_setting_int(CFG, 'General', 'recentsearch_startup', 1))
-        BACKLOG_STARTUP = bool(check_setting_int(CFG, 'General', 'backlog_startup', 1))
+        RECENTSEARCH_STARTUP = bool(check_setting_int(CFG, 'General', 'recentsearch_startup', 0))
+        BACKLOG_STARTUP = bool(check_setting_int(CFG, 'General', 'backlog_startup', 0))
         SKIP_REMOVED_FILES = bool(check_setting_int(CFG, 'General', 'skip_removed_files', 0))
 
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
@@ -1052,7 +1052,7 @@ def initialize(consoleLogging=True):
             if hasattr(curNzbProvider, 'enable_recentsearch'):
                 curNzbProvider.enable_recentsearch = bool(check_setting_int(CFG, curNzbProvider.getID().upper(),
                                                                        curNzbProvider.getID() + '_enable_recentsearch',
-                                                                       1))
+                                                                     1))
             if hasattr(curNzbProvider, 'enable_backlog'):
                 curNzbProvider.enable_backlog = bool(check_setting_int(CFG, curNzbProvider.getID().upper(),
                                                                        curNzbProvider.getID() + '_enable_backlog',
@@ -1127,14 +1127,14 @@ def initialize(consoleLogging=True):
                                                    cycleTime=update_interval,
                                                    threadName="RECENTSEARCHER",
                                                    run_delay=update_now if RECENTSEARCH_STARTUP
-                                                   else update_interval)
+                                                   else datetime.timedelta(minutes=5))
 
         update_interval = datetime.timedelta(minutes=BACKLOG_FREQUENCY)
         backlogSearchScheduler = searchBacklog.BacklogSearchScheduler(searchBacklog.BacklogSearcher(),
                                                                       cycleTime=update_interval,
                                                                       threadName="BACKLOG",
                                                                       run_delay=update_now if BACKLOG_STARTUP
-                                                                      else update_interval)
+                                                                      else datetime.timedelta(minutes=10))
 
         search_intervals = {'15m': 15, '45m': 45, '90m': 90, '4h': 4 * 60, 'daily': 24 * 60}
         if CHECK_PROPERS_INTERVAL in search_intervals:

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -740,3 +740,8 @@ class ConfigMigrator():
             sickbeard.EPISODE_VIEW_SORT = 'time'
         sickbeard.EPISODE_VIEW_DISPLAY_PAUSED = bool(check_setting_int(self.config_obj, 'GUI', 'coming_eps_display_paused', 0))
         sickbeard.EPISODE_VIEW_MISSED_RANGE = check_setting_int(self.config_obj, 'GUI', 'coming_eps_missed_range', 7)
+
+    def _migrate_v8(self):
+        # removing settings from gui and making it a hidden debug option
+        sickbeard.RECENTSEARCH_STARTUP = False
+        sickbeard.BACKLOG_STARTUP = False

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -38,6 +38,8 @@ class BacklogSearchScheduler(scheduler.Scheduler):
     def nextRun(self):
         if self.action._lastBacklog <= 1:
             return datetime.date.today()
+        elif (self.action._lastBacklog + self.action.cycleTime) < datetime.date.today().toordinal():
+            return datetime.date.today()
         else:
             return datetime.date.fromordinal(self.action._lastBacklog + self.action.cycleTime)
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1630,7 +1630,6 @@ class ConfigSearch(MainHandler):
                    backlog_days=None, backlog_frequency=None, recentsearch_frequency=None,
                    nzb_method=None, torrent_method=None, usenet_retention=None,
                    download_propers=None, check_propers_interval=None, allow_high_priority=None,
-                   backlog_startup=None, recentsearch_startup=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_path=None, torrent_verify_cert=None,
                    torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None, ignore_words=None, require_words=None):
@@ -1662,9 +1661,6 @@ class ConfigSearch(MainHandler):
         sickbeard.CHECK_PROPERS_INTERVAL = check_propers_interval
 
         sickbeard.ALLOW_HIGH_PRIORITY = config.checkbox_to_value(allow_high_priority)
-
-        sickbeard.RECENTSEARCH_STARTUP = config.checkbox_to_value(recentsearch_startup)
-        sickbeard.BACKLOG_STARTUP = config.checkbox_to_value(backlog_startup)
 
         sickbeard.SAB_USERNAME = sab_username
         sickbeard.SAB_PASSWORD = sab_password


### PR DESCRIPTION
Change backlog search delayed start time to occur 10 minutes after start up
Change UI footer to display time left until a backlog search rather than start time