### PR TITLE
Add handling of exceptional case with missing network name (NoneType) in...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Change anime release groups to in memory storage for lowered latency
 * Change adjust menu delay and hover styling
 * Fix provider list color
+* Add handling of exceptional case with missing network name (NoneType) in Episode View 
 
 [develop changelog]
 

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -768,7 +768,9 @@ class CMD_ComingEpisodes(ApiCall):
                 (b['data_show_name'], b['parsed_datetime'], b['season'], b['episode'])))
         }
 
-        def value_maybe_article(value=''):
+        def value_maybe_article(value=None):
+            if None is value:
+                return ''
             return (remove_article(value.lower()), value.lower())[sickbeard.SORT_ARTICLE]
 
         # add parsed_datetime to the dict

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -415,7 +415,9 @@ class MainHandler(RequestHandler):
                 (b['localtime'], b['data_show_name'], b['season'], b['episode'])))
         }
 
-        def value_maybe_article(value=''):
+        def value_maybe_article(value=None):
+            if None is value:
+                return ''
             return (remove_article(value.lower()), value.lower())[sickbeard.SORT_ARTICLE]
 
         # add localtime to the dict


### PR DESCRIPTION
... Episode View.

A show should always have an original broadcaster (network), however, user input errors mean that a show can get added without this fundamental detail.

This addresses issue #156