### PR TITLE
Fix SSL authentication on Synology stations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@
 * Fix issue where PMS text wasn't initialised on the config/notifications page and added info about Plex clients
 * Add ability to test Plex Server(s) on config/notifications page
 * Add percentage of episodes downloaded to footer and remove double spaces in text
+* Fix SSL authentication on Synology stations
 
 [develop changelog]
 * Change uT params from unicode to str.format as magnet URLs worked but sending files in POST bodies failed

--- a/sickbeard/clients/download_station.py
+++ b/sickbeard/clients/download_station.py
@@ -36,7 +36,7 @@ class DownloadStationAPI(GenericClient):
         auth_url = self.host + 'webapi/auth.cgi?api=SYNO.API.Auth&version=2&method=login&account=' + self.username + '&passwd=' + self.password + '&session=DownloadStation&format=sid'
 
         try:
-            self.response = self.session.get(auth_url)
+            self.response = self.session.get(auth_url, verify=False)
             self.auth = self.response.json()['data']['sid']
         except:
             return None


### PR DESCRIPTION
Disables certification verification for SYNO requests; not an ideal fix as a mitm process can be established as a result.  However, permits using SSL until a full fix is available.