### PR TITLE
Change to reduce the time taken to "Update shows" with show data.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,14 +34,23 @@
 * Fix Recent Search running status on Manage Searches page
 * Change to no longer require restart with the "Scan and post process" option on page config/Post Processing
 * Add validation when using Release Group token on page config Post Processing/Episode Naming/Name pattern/Custom
-* Change IMDb updater to a toggleable option under General Settings (disabled by default due to slow operations)
 * Change to simplify and reduce logging output of Recent-Search and Backlog processes
+* Add show names to items listed during startup in the loading from database phase 
+* Add "Enable IMDb info" option to config/General/Interface
+* Change to not display IMDb info on UI when "Enable IMDb info" is disabled
+* Change genre tags on displayShow page to link to IMDb instead of Trakt
+* Change to reduce the time taken to "Update shows" with show data
+* Change to stop updating the IMDb info during the scheduled daily update for every show
+* Change to update the IMDb info for a show after snatching an episode for it
 
 [develop changelog]
 * Fix traceback error when using the menu item Manage/Update Kodi
 * Change BET network logo filename to lower case
 * Change redirect from home to showlistView on changing Layout on showlistView
 * Fix the return flow from calls to the redirect function from executing incorrect code
+* Fix being able to actually turn IMDb off when it has been turned on
+* Remove IMDb option from General Settings
+* Change IMDb option to enable by default now the slow operation has been eliminated from process flows
 
 
 ### 0.7.2 (2015-03-10 17:05:00 UTC)

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1132,11 +1132,12 @@ span.imdbstars, span.imdbstars > * {
 	display: inline-block;
 	font-size:10px;
 	background: url(../images/rating.png) 0 -12px repeat-x;
+	margin-bottom:-1px
 }
 
 #showinfo .flag {
-	margin: 0 3px 0 0;
-	vertical-align: baseline;
+	margin: 0 3px 1px 0;
+	vertical-align: middle;
 }
 
 #showinfo .imdb-info {
@@ -1146,6 +1147,10 @@ span.imdbstars, span.imdbstars > * {
 #showinfo a.service {
 	margin: 0 3px 0 0;
 	font-size: 16px;
+}
+
+#showinfo a.service img {
+	margin-bottom:1px
 }
 
 ul.tags {
@@ -1158,7 +1163,7 @@ ul.tags {
 ul.tags li {
 	margin-right: 4px;
 	margin-bottom: 5px;
-	padding: 3px 4px 3px 25px;
+	padding: 3px 7px 3px 23px;
 	background: url(../images/tag.png) no-repeat scroll 5px 4px #555;
 	border-radius: 3px;
 	border: 1px solid #111;

--- a/gui/slick/interfaces/default/config_general.tmpl
+++ b/gui/slick/interfaces/default/config_general.tmpl
@@ -133,16 +133,6 @@
 						</div>
 
 						<div class="field-pair">
-							<label for="use_imdb">
-								<span class="component-title">Enable IMDb info</span>
-								<span class="component-desc">
-									<input type="checkbox" name="use_imdb" id="use_imdb" #if $sickbeard.USE_IMDB then 'checked="checked"' else ''#>
-									<p>fetches show rating and country flag (does slow show updating process)</p>
-								</span>
-							</label>
-						</div>
-
-						<div class="field-pair">
 							<label>
 								<span class="component-title">Show root directories</span>
 								<span class="component-desc">
@@ -244,6 +234,16 @@
 										<option value="episodes" #if $sickbeard.DEFAULT_HOME == 'episodes' then 'selected="selected"' else ''#>Episodes</option>
 										<option value="history" #if $sickbeard.DEFAULT_HOME == 'history' then 'selected="selected"' else ''#>History</option>
 									</select>
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="use_imdb_info">
+								<span class="component-title">Enable IMDb info</span>
+								<span class="component-desc">
+									<input type="checkbox" name="use_imdb_info" id="use_imdb_info" #if $sickbeard.USE_IMDB_INFO then 'checked="checked"' else ''#>
+									<p>for ui links, display show; ratings, country flag, year, runtime, and genre tags</p>
 								</span>
 							</label>
 						</div>

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -19,23 +19,25 @@
 <script type="text/javascript" src="$sbRoot/js/displayShow.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/sceneExceptionsTooltip.js?$sbPID"></script>
+#if $sickbeard.USE_IMDB_INFO:
 <script type="text/javascript" src="$sbRoot/js/ratingTooltip.js?$sbPID"></script>
+#end if
 <script type="text/javascript" src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/ajaxEpSubtitles.js?$sbPID"></script>
 <script type="text/javascript" charset="utf-8">
 <!--
 \$(document).ready(function(){
-    #set $fuzzydate = 'airdate'
-    #if $sickbeard.FUZZY_DATING:
+#set $fuzzydate = 'airdate'
+#if $sickbeard.FUZZY_DATING:
     fuzzyMoment({
         containerClass : '.${fuzzydate}',
         dateHasTime : false,
         dateFormat : '${sickbeard.DATE_PRESET}',
         timeFormat : '${sickbeard.TIME_PRESET}',
-        trimZero : #if $sickbeard.TRIM_ZERO then "true" else "false"#
+        trimZero : #if $sickbeard.TRIM_ZERO then 'true' else 'false'#
     });
-    #end if
-    #raw
+#end if
+#raw
     $('.addQTip').each(function () {
         $(this).css({'cursor':'help', 'text-shadow':'0px 0px 0.5px #666'});
         $(this).qtip({
@@ -44,13 +46,13 @@
             style: {classes:'qtip-rounded qtip-shadow'}
         });
     });
-    #end raw
-	
+#end raw
+#if $sickbeard.USE_IMDB_INFO:
 	\$.fn.generateStars = function() {
 		return this.each(function(i,e){\$(e).html(\$('<span/>').width(\$(e).text()*12));});
 	};
-
 	\$('.imdbstars').generateStars();
+#end if
 	TVShowList = [${tvshow_id_csv}]
 });
 //-->
@@ -59,22 +61,22 @@
 	<div class="pull-left form-inline">
 		Change Show:
 		<div class="navShow"><img id="prevShow" src="$sbRoot/images/prev.png" alt="&lt;&lt;" title="Prev Show" /></div>
-			<select id="pickShow" class="form-control form-control-inline input-sm">
-			#for $curShowList in $sortedShowLists:
-				#set $curShowType = $curShowList[0]
-				#set $curShowList = $curShowList[1]
+		<select id="pickShow" class="form-control form-control-inline input-sm">
+#for $curShowList in $sortedShowLists:
+    #set $curShowType = $curShowList[0]
+    #set $curShowList = $curShowList[1]
 
-				#if len($sortedShowLists) > 1:
-					<optgroup label="$curShowType">
-				#end if
-					#for $curShow in $curShowList:
-					<option value="$curShow.indexerid" #if $curShow == $show then "selected=\"selected\"" else ""#>$curShow.name</option>
-					#end for
-				#if len($sortedShowLists) > 1:
-					</optgroup>
-				#end if
-			#end for
-			</select>
+    #if 1 < len($sortedShowLists):
+			<optgroup label="$curShowType">
+    #end if
+    #for $curShow in $curShowList:
+			<option value="$curShow.indexerid" #if $curShow == $show then 'selected="selected"' else ''#>$curShow.name</option>
+    #end for
+    #if 1 < len($sortedShowLists):
+			</optgroup>
+    #end if
+#end for
+		</select>
 		<div class="navShow"><img id="nextShow" src="$sbRoot/images/next.png" alt="&gt;&gt;" title="Next Show" /></div>
 	</div>
 
@@ -83,57 +85,52 @@
 	<div id="showtitle" data-showname="$show.name">
 		<h1 class="title" id="scene_exception_$show.indexerid"><span>$show.name</span></h1>
 	</div>
-
 	
-		#if $seasonResults:
-		##There is a special/season_0?##
-		#if int($seasonResults[-1]["season"]) == 0:
-			#set $season_special = 1
-		#else: 
-			#set $season_special = 0
-		#end if
+#if $seasonResults:
+    ##There is a special/season_0?##
+    #set $season_special = (0, 1)[0 == int($seasonResults[-1]['season'])]
 
-		#if not $sickbeard.DISPLAY_SHOW_SPECIALS and $season_special:
-			$seasonResults.pop(-1)
-		#end if
+    #if not $sickbeard.DISPLAY_SHOW_SPECIALS and $season_special:
+	$seasonResults.pop(-1)
+    #end if
 
-		<span class="h2footer displayspecials pull-right">
-			#if $season_special:
-			Display Specials:
-				#if sickbeard.DISPLAY_SHOW_SPECIALS:
-					<a class="inner" href="$sbRoot/toggleDisplayShowSpecials/?show=$show.indexerid">Hide</a>
-				#else:
-					<a class="inner" href="$sbRoot/toggleDisplayShowSpecials/?show=$show.indexerid">Show</a>
-				#end if
-			#end if
-		</span>
+	<span class="h2footer displayspecials pull-right">
+    #if $season_special:
+		Display Specials:
+        #if sickbeard.DISPLAY_SHOW_SPECIALS:
+		<a class="inner" href="$sbRoot/toggleDisplayShowSpecials/?show=$show.indexerid">Hide</a>
+        #else:
+		<a class="inner" href="$sbRoot/toggleDisplayShowSpecials/?show=$show.indexerid">Show</a>
+        #end if
+    #end if
+	</span>
 		
-		<div class="h2footer pull-right"> 
-			<span>
-			#if (len($seasonResults) > 14):
-				<select id="seasonJump" class="form-control input-sm" style="position: relative; top: -4px;">
-					<option value="jump">Jump to Season</option>
-				#for $seasonNum in $seasonResults:
-					<option value="#season-$seasonNum["season"]">#if int($seasonNum["season"]) == 0 then "Specials" else "Season " + str($seasonNum["season"])#</option>
-				#end for
-				</select>
-			#else:
-				Season:
-				#for $seasonNum in $seasonResults:
-					#if int($seasonNum["season"]) == 0:
-						<a href="#season-$seasonNum["season"]">Specials</a>
-					#else:
-						<a href="#season-$seasonNum["season"]">${str($seasonNum["season"])}</a>
-					#end if
-					#if $seasonNum != $seasonResults[-1]:
-						<span class="separator">|</span>
-					#end if
-				#end for
-			#end if
-			</span>
+	<div class="h2footer pull-right">
+		<span>
+    #if (len($seasonResults) > 14):
+			<select id="seasonJump" class="form-control input-sm" style="position: relative; top: -4px;">
+				<option value="jump">Jump to Season</option>
+        #for $seasonNum in $seasonResults:
+				<option value="#season-$seasonNum['season']">#if 0 == int($seasonNum['season']) then 'Specials' else 'Season ' + str($seasonNum['season'])#</option>
+        #end for
+			</select>
+    #else:
+			Season:
+        #for $seasonNum in $seasonResults:
+            #if 0 == int($seasonNum['season']):
+			<a href="#season-$seasonNum['season']">Specials</a>
+            #else:
+			<a href="#season-$seasonNum['season']">${str($seasonNum['season'])}</a>
+            #end if
+            #if $seasonNum != $seasonResults[-1]:
+			<span class="separator">|</span>
+            #end if
+        #end for
+    #end if
+		</span>
 
-		#end if
-		</div>
+#end if
+	</div>
 	
 	<div class="clearfix"></div>
     
@@ -142,22 +139,27 @@
 		$show_message
 	</div>
 #end if
-	
+
 	<div id="container">
 		<div id="posterCol">
-			<a href="$sbRoot/showPoster/?show=$show.indexerid&amp;which=poster" rel="dialog" title="View Poster for $show.name"><img src="$sbRoot/showPoster/?show=$show.indexerid&amp;which=poster_thumb" class="tvshowImg" alt=""/></a>
+			<a href="$sbRoot/showPoster/?show=$show.indexerid&amp;which=poster" rel="dialog" title="View Poster for $show.name">
+			<img #echo ('', 'style="height:271px" ')[not $sickbeard.USE_IMDB_INFO or not $show.imdbid or 'year' not in $show.imdb_info]#src="$sbRoot/showPoster/?show=$show.indexerid&amp;which=poster_thumb" class="tvshowImg" alt="" /></a>
 		</div>
 
 		<div id="showCol">
-		
+
 			<div id="showinfo">
-#if 'rating' in $show.imdb_info:
-    #set $rating_tip = str($show.imdb_info['rating']) + " / 10" + " Stars" + "<br />" + str($show.imdb_info['votes']) + " Votes"
+#if $sickbeard.USE_IMDB_INFO and 'rating' in $show.imdb_info
+    #if '' != $show.imdb_info['votes']
+        #set $rating_tip = '%s of 10 stars<br />%s votes' % (str($show.imdb_info['rating']), str($show.imdb_info['votes']))
 				<span class="imdbstars" qtip-content="$rating_tip">$show.imdb_info['rating']</span>
+    #else
+				<span class="imdb-info">[ No votes available ]</span>
+    #end if
 #end if
-				
+
 #set $_show = $show
-#if not $show.imdbid
+#if not $sickbeard.USE_IMDB_INFO or not $show.imdbid
 				<span>($show.startyear) - $show.runtime minutes - </span>
 #else
     #if 'country_codes' in $show.imdb_info:
@@ -175,107 +177,111 @@
 				<a class="service" href="<%= anon_url('http://thexem.de/search?q=', _show.name) %>" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;" title="http://thexem.de/search?q-$show.name"><img alt="[xem]" height="16" width="16" src="$sbRoot/images/xem.png" /></a>
 #end if
 			</div>
-
+#if not $sickbeard.USE_IMDB_INFO or not $show.imdbid
+## Disabling these trackt tags as they 404 on trakt2.0, remove False to re-enable
+    #if False and $show.genre:
 			<div id="tags">
 				<ul class="tags">
-					#if not $show.imdbid
-					#if $show.genre:
-					#for $genre in $show.genre[1:-1].split('|')
-						<a href="<%= anon_url('http://trakt.tv/shows/popular/', genre.lower()) %>" target="_blank" title="View other popular $genre shows on trakt.tv."><li>$genre</li></a>
-					#end for
-					#end if
-					#end if
-					#if 'year' in $show.imdb_info:
-					#for $imdbgenre in $show.imdb_info['genres'].replace('Sci-Fi','Science-Fiction').split('|')
-						<a href="<%= anon_url('http://trakt.tv/shows/popular/', imdbgenre.lower()) %>" target="_blank" title="View other popular $imdbgenre shows on trakt.tv."><li>$imdbgenre</li></a>
-					#end for
-					#end if
+        #for $genre in $show.genre[1:-1].split('|')
+					<li><a href="<%= anon_url('http://trakt.tv/shows/popular/', genre.lower()) %>" target="_blank" title="View other popular $genre shows on trakt.tv">$genre</a></li>
+        #end for
 				</ul>
 			</div>
-		
+    #end if
+#end if
+#if $sickbeard.USE_IMDB_INFO and 'year' in $show.imdb_info:
+			<div id="tags">
+				<ul class="tags">
+    #for $imdbgenre in $show.imdb_info['genres'].split('|')
+					<li><a href="<%= anon_url('http://www.imdb.com/genre/', imdbgenre) %>" target="_blank" title="View other popular $imdbgenre shows on imdb.com">$imdbgenre.replace('Sci-Fi', 'Science-Fiction')</a></li>
+    #end for
+				</ul>
+			</div>
+#end if
+
 			<div id="summary">
 				<table class="summaryTable pull-left">
-				#if $show.network and $show.airs:
+#if $show.network and $show.airs:
 					<tr><td class="showLegend grey-text">Originally airs</td><td>$show.airs #if not $network_timezones.test_timeformat($show.airs) then ' <font color="#FF0000"><b>(invalid Timeformat)</b></font> ' else ''# on $show.network</td></tr>
-				#else if $show.network:
+#else if $show.network:
 					<tr><td class="showLegend grey-text">Originally airs</td><td>$show.network</td></tr>
-				#else if $show.airs:
+#else if $show.airs:
 					<tr><td class="showLegend grey-text">Originally airs</td><td>$show.airs #if not $network_timezones.test_timeformat($show.airs) then ' <font color="#FF0000"><b>(invalid Timeformat)</b></font> ' else ''#</td></tr>
-				#end if
+#end if
 					<tr><td class="showLegend grey-text">Status</td><td>$show.status</td></tr>
-				#if $showLoc[1]:
+#if $showLoc[1]:
 					<tr><td class="showLegend grey-text">Location</td><td>$showLoc[0]</td></tr>
-				#else:
+#else:
 					<tr><td class="showLegend grey-text"><span style="color: red;">Location</span></td><td><span style="color: red;">$showLoc[0]</span> (dir is missing)</td></tr>
-				#end if
-				#set $anyQualities, $bestQualities = $Quality.splitQuality(int($show.quality))
+#end if
+#set $anyQualities, $bestQualities = $Quality.splitQuality(int($show.quality))
 					<tr><td class="showLegend grey-text">Quality</td><td>
-				#if $show.quality in $qualityPresets:
-					<span class="quality $qualityPresetStrings[$show.quality]">$qualityPresetStrings[$show.quality]</span>
-				#else:
-				#if $anyQualities:
-					<i class="grey-text">Initial ...</i> <%= ', '.join([Quality.qualityStrings[x] for x in sorted(anyQualities)])%> #if $bestQualities then " </br> " else ""#
-				#end if
-				#if $bestQualities:
-					<i class="grey-text">Replace with ...</i> <%= ', '.join([Quality.qualityStrings[x] for x in sorted(bestQualities)])%>
-				#end if
-				#end if
+#if $show.quality in $qualityPresets:
+						<span class="quality $qualityPresetStrings[$show.quality]">$qualityPresetStrings[$show.quality]</span>
+#else:
+	#if $anyQualities:
+						<i class="grey-text">Initial ...</i> <%= ', '.join([Quality.qualityStrings[x] for x in sorted(anyQualities)])%> #if $bestQualities then ' </br> ' else ''#
+	#end if
+    #if $bestQualities:
+						<i class="grey-text">Replace with ...</i> <%= ', '.join([Quality.qualityStrings[x] for x in sorted(bestQualities)])%>
+    #end if
+#end if</td></tr>
 					<tr><td class="showLegend grey-text">Scene name</td><td>#if $show.exceptions then $exceptions_string else $show.name#</td></tr>
 					
-				#if $show.rls_ignore_words:
+#if $show.rls_ignore_words:
 					<tr><td class="showLegend grey-text">Ignore with any of</td><td>#echo $show.rls_ignore_words#</td></tr>
-				#end if
-				#if $show.rls_require_words:
+#end if
+#if $show.rls_require_words:
 					<tr><td class="showLegend grey-text">Require one of</td><td>#echo $show.rls_require_words#</td></tr>
-				#end if
+#end if
 
-				#if $bwl and $bwl.whitelist:
+#if $bwl and $bwl.whitelist:
 					<tr><td class="showLegend grey-text">Whitelist group#if len($bwl.whitelist)>1 then 's' else ''#</td>
 					<td>#echo ', '.join($bwl.whitelist)#</td>
 					</tr>
-				#end if
-				#if $bwl and $bwl.blacklist:
+#end if
+#if $bwl and $bwl.blacklist:
 					<tr><td class="showLegend grey-text">Blacklist group#if len($bwl.blacklist)>1 then 's' else ''#</td>
 					<td>#echo ', '.join($bwl.blacklist)#</td>
 					</tr>
-				#end if
+#end if
 
 					<tr><td class="showLegend grey-text">Size</td><td>$sickbeard.helpers.human(sickbeard.helpers.get_size($showLoc[0]))</td></tr>
-
 				</table>
 			
 				<table class="options-on-right">
-					<tr><td class="showLegendRight grey-text">Paused</td><td><img src="$sbRoot/images/#if int($show.paused) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					#if $anyQualities + $bestQualities
-					<tr><td class="showLegendRight grey-text">Archive on first match</td><td><img src="$sbRoot/images/#if int($show.archive_firstmatch) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					#end if
-					<tr><td class="showLegendRight grey-text">Flat folder structure</td><td><img src="$sbRoot/images/#if $show.flatten_folders == 1 or $sickbeard.NAMING_FORCE_FOLDERS then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					<tr><td class="showLegendRight grey-text">Air by date naming</td><td><img src="$sbRoot/images/#if int($show.air_by_date) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					<tr><td class="showLegendRight grey-text">Use DVD order</td><td><img src="$sbRoot/images/#if int($show.dvdorder) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					<tr><td class="showLegendRight grey-text">Scene numbering</td><td><img src="$sbRoot/images/#if int($show.scene) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					#if $sickbeard.USE_SUBTITLES
-					<tr><td class="showLegendRight grey-text">Subtitles</td><td><img src="$sbRoot/images/#if int($show.subtitles) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					#end if
-					<tr><td class="showLegendRight grey-text">Show is sports</td><td><img src="$sbRoot/images/#if int($show.is_sports) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
-					<tr><td class="showLegendRight grey-text">Show is anime</td><td><img src="$sbRoot/images/#if int($show.is_anime) == 1 then 'yes16.png" title="Yes" alt="Yes' else 'no16.png" title="No" alt="No'#" width="16" height="16" /></td></tr>
+#set $no = 'no16.png" title="No" alt="No'
+#set $yes = 'yes16.png" title="Yes" alt="Yes'
+					<tr><td class="showLegendRight grey-text">Paused</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.paused)]#" width="16" height="16" /></td></tr>
+#if $anyQualities + $bestQualities
+					<tr><td class="showLegendRight grey-text">Archive on first match</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.archive_firstmatch)]#" width="16" height="16" /></td></tr>
+#end if
+					<tr><td class="showLegendRight grey-text">Flat folder structure</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == $show.flatten_folders or $sickbeard.NAMING_FORCE_FOLDERS]#" width="16" height="16" /></td></tr>
+					<tr><td class="showLegendRight grey-text">Air by date naming</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.air_by_date)]#" width="16" height="16" /></td></tr>
+					<tr><td class="showLegendRight grey-text">Use DVD order</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.dvdorder)]#" width="16" height="16" /></td></tr>
+					<tr><td class="showLegendRight grey-text">Scene numbering</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.scene)]#" width="16" height="16" /></td></tr>
+#if $sickbeard.USE_SUBTITLES
+					<tr><td class="showLegendRight grey-text">Subtitles</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.subtitles)]#" width="16" height="16" /></td></tr>
+#end if
+					<tr><td class="showLegendRight grey-text">Show is sports</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.is_sports)]#" width="16" height="16" /></td></tr>
+					<tr><td class="showLegendRight grey-text">Show is anime</td><td><img src="$sbRoot/images/#echo ($no, $yes)[1 == int($show.is_anime)]#" width="16" height="16" /></td></tr>
 					<tr><td class="showLegendRight grey-text">Info language</td><td><img src="$sbRoot/images/flags/${show.lang}.png" width="16" height="11" alt="$show.lang" title="$show.lang" /></td></tr>
 				</table>
 			</div>
-		
 		</div>
 	</div>
-		
+
 	<div class="clearfix"></div>
-		
+
 	<div class="pull-left" style="padding-bottom: 10px;">
 		Change selected episodes to 
 		<select id="statusSelect" class="form-control form-control-inline input-sm">
-			#for $curStatus in [$WANTED, $SKIPPED, $ARCHIVED, $IGNORED, $FAILED] + sorted($Quality.DOWNLOADED):
-			#if $curStatus == $DOWNLOADED:
-			#continue
-			#end if
+#for $curStatus in [$WANTED, $SKIPPED, $ARCHIVED, $IGNORED, $FAILED] + sorted($Quality.DOWNLOADED):
+    #if $DOWNLOADED == $curStatus:
+        #continue
+    #end if
 			<option value="$curStatus">$statusStrings[$curStatus]</option>
-			#end for
+#end for
 		</select>
 		<input type="hidden" id="showID" value="$show.indexerid" />
 		<input type="hidden" id="indexer" value="$show.indexer" />
@@ -297,197 +303,194 @@
 		</div>
 	</div>
 
-<br />	
+	<br />	
 
-<table class="sickbeardTable display_show" cellspacing="0" border="0" cellpadding="0">
+	<table class="sickbeardTable display_show" cellspacing="0" border="0" cellpadding="0">
 
 #set $curSeason = -1
 #set $odd = 0
 
-	#for $epResult in $sqlResults:
-		#set $epStr = str($epResult["season"]) + "x" + str($epResult["episode"])
-		#if not $epStr in $epCats:
-			#continue
-		#end if
+#for $epResult in $sqlResults:
+    #set $epStr = str($epResult['season']) + 'x' + str($epResult['episode'])
+    #if not $epStr in $epCats:
+        #continue
+    #end if
 
-		#if not $sickbeard.DISPLAY_SHOW_SPECIALS and int($epResult["season"]) == 0:
-			#continue
-		#end if	
+    #if not $sickbeard.DISPLAY_SHOW_SPECIALS and 0 == int($epResult['season']):
+        #continue
+    #end if	
 
-		#set $scene = False
-		#set $scene_anime = False
-		#if not $show.air_by_date and not $show.is_sports and not $show.is_anime and $show.is_scene:
-			#set $scene = True
-		#elif not $show.air_by_date and not $show.is_sports and $show.is_anime and $show.is_scene:
-			#set $scene_anime = True
-		#end if
+    #set $scene = False
+    #set $scene_anime = False
+    #if not $show.air_by_date and not $show.is_sports and not $show.is_anime and $show.is_scene:
+        #set $scene = True
+    #elif not $show.air_by_date and not $show.is_sports and $show.is_anime and $show.is_scene:
+        #set $scene_anime = True
+    #end if
 
-		#set ($dfltSeas, $dfltEpis, $dfltAbsolute) = (0, 0, 0)
+    #set ($dfltSeas, $dfltEpis, $dfltAbsolute) = (0, 0, 0)
 
-		#if (epResult["season"], epResult["episode"]) in $xem_numbering:
-			#set ($dfltSeas, $dfltEpis) = $xem_numbering[(epResult["season"], epResult["episode"])]
-		#end if
+    #if (epResult['season'], epResult['episode']) in $xem_numbering:
+        #set ($dfltSeas, $dfltEpis) = $xem_numbering[(epResult['season'], epResult['episode'])]
+    #end if
 
-		#if epResult["absolute_number"] in $xem_absolute_numbering:
-			#set $dfltAbsolute = $xem_absolute_numbering[epResult["absolute_number"]]
-		#end if
+    #if epResult['absolute_number'] in $xem_absolute_numbering:
+        #set $dfltAbsolute = $xem_absolute_numbering[epResult['absolute_number']]
+    #end if
 
-		#if epResult["absolute_number"] in $scene_absolute_numbering:
-			#set $scAbsolute = $scene_absolute_numbering[epResult["absolute_number"]]
-			#set $dfltAbsNumbering = False
-		#else
-			#set $scAbsolute = $dfltAbsolute
-			#set $dfltAbsNumbering = True
-		#end if
+    #if epResult['absolute_number'] in $scene_absolute_numbering:
+        #set $scAbsolute = $scene_absolute_numbering[epResult['absolute_number']]
+        #set $dfltAbsNumbering = False
+    #else
+        #set $scAbsolute = $dfltAbsolute
+        #set $dfltAbsNumbering = True
+    #end if
 
-		#if (epResult["season"], epResult["episode"]) in $scene_numbering:
-			#set ($scSeas, $scEpis) = $scene_numbering[(epResult["season"], epResult["episode"])]
-			#set $dfltEpNumbering = False
-		#else
-			#set ($scSeas, $scEpis) = ($dfltSeas, $dfltEpis)
-			#set $dfltEpNumbering = True
-		#end if
+    #if (epResult['season'], epResult['episode']) in $scene_numbering:
+        #set ($scSeas, $scEpis) = $scene_numbering[(epResult['season'], epResult['episode'])]
+        #set $dfltEpNumbering = False
+    #else
+        #set ($scSeas, $scEpis) = ($dfltSeas, $dfltEpis)
+        #set $dfltEpNumbering = True
+    #end if
 
-		#if int($epResult["season"]) != $curSeason:
-			<tr id="season-$epResult['season']">
-				<th class="row-seasonheader" colspan="13" style="width: auto;"><h3><a name="season-$epResult["season"]"></a>#if int($epResult["season"]) == 0 then "Specials" else "Season " + str($epResult["season"])#</h3></th>
-			</tr>
+    #if int($epResult['season']) != $curSeason:
+		<tr id="season-$epResult['season']">
+			<th class="row-seasonheader" colspan="13" style="width: auto;"><h3><a name="season-$epResult['season']"></a>#if 0 == int($epResult['season']) then 'Specials' else 'Season ' + str($epResult['season'])#</h3></th>
+		</tr>
 			
-			<tr id="season-$epResult["season"]-cols" class="seasoncols">
-				<th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="$epResult["season"]" /></th>
-				<th class="col-metadata">NFO</th>
-				<th class="col-metadata">TBN</th>
-				<th class="col-ep">Episode</th>
-			#if $show.is_anime:
-				<th class="col-ep">Absolute</th>
-			#end if
-			#if $scene:
-				<th class="col-ep">Scene</th>
-			#end if
-			#if $scene_anime:
-				<th class="col-ep">Scene Absolute</th>
-			#end if
-				<th class="col-name">Name</th>
-				<th class="col-airdate">Airdate</th>
-			#if $sickbeard.USE_SUBTITLES and $show.subtitles:
-				<th class="col-subtitles">Subtitles</th>
-			#end if
-				<th class="col-status">Status</th>
-				<th class="col-search">Search</th>
-			</tr>
-			#set $curSeason = int($epResult["season"])
-		#end if    
+		<tr id="season-$epResult['season']-cols" class="seasoncols">
+			<th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="$epResult['season']" /></th>
+			<th class="col-metadata">NFO</th>
+			<th class="col-metadata">TBN</th>
+			<th class="col-ep">Episode</th>
+        #if $show.is_anime:
+			<th class="col-ep">Absolute</th>
+        #end if
+        #if $scene:
+			<th class="col-ep">Scene</th>
+        #end if
+        #if $scene_anime:
+			<th class="col-ep">Scene Absolute</th>
+        #end if
+			<th class="col-name">Name</th>
+			<th class="col-airdate">Airdate</th>
+        #if $sickbeard.USE_SUBTITLES and $show.subtitles:
+			<th class="col-subtitles">Subtitles</th>
+        #end if
+			<th class="col-status">Status</th>
+			<th class="col-search">Search</th>
+		</tr>
+        #set $curSeason = int($epResult['season'])
+    #end if    
 
-		#set $epLoc = $epResult["location"]
+    #set $epLoc = $epResult['location']
 		
 		<tr class="$Overview.overviewStrings[$epCats[$epStr]] season-$curSeason seasonstyle">
 		
-		<td class="col-checkbox">
-		
-		#if int($epResult["status"]) != $UNAIRED
-			<input type="checkbox" class="epCheck" id="<%=str(epResult["season"])+'x'+str(epResult["episode"])%>" name="<%=str(epResult["season"]) +"x"+str(epResult["episode"]) %>" />
-		#end if
-		</td>
+			<td class="col-checkbox">
+    #if $UNAIRED != int($epResult['status']) 
+				<input type="checkbox" class="epCheck" id="<%=str(epResult['season'])+'x'+str(epResult['episode'])%>" name="<%=str(epResult['season']) +'x'+str(epResult['episode']) %>" />
+    #end if
+			</td>
     
-		<td align="center"><img src="$sbRoot/images/#if $epResult["hasnfo"] == 1 then "nfo.gif\" alt=\"Y" else "nfo-no.gif\" alt=\"N"#" width="23" height="11" /></td>
+			<td align="center"><img src="$sbRoot/images/#if 1 == $epResult['hasnfo'] then 'nfo.gif" alt="Y' else 'nfo-no.gif" alt="N'#" width="23" height="11" /></td>
 		
-		<td align="center"><img src="$sbRoot/images/#if $epResult["hastbn"] == 1 then "tbn.gif\" alt=\"Y" else "tbn-no.gif\" alt=\"N"#" width="23" height="11" /></td>
+			<td align="center"><img src="$sbRoot/images/#if 1 == $epResult['hastbn'] then 'tbn.gif" alt="Y' else 'tbn-no.gif" alt="N'#" width="23" height="11" /></td>
 		
 		<td align="center">
-			#if $epLoc and $show._location and $epLoc.lower().startswith($show._location.lower()):
-				#set $epLoc = $epLoc[len($show._location)+1:]
-			#elif $epLoc and (not $epLoc.lower().startswith($show._location.lower()) or not $show._location):
-				#set $epLoc = $epLoc
-			#end if
+    #if $epLoc and $show._location and $epLoc.lower().startswith($show._location.lower()):
+        #set $epLoc = $epLoc[len($show._location)+1:]
+    #elif $epLoc and (not $epLoc.lower().startswith($show._location.lower()) or not $show._location):
+        #set $epLoc = $epLoc
+    #end if
 		
-			#if $epLoc != "" and $epLoc != None:
-				<span title="$epLoc" class="addQTip">$epResult["episode"]</span>
-			#else
-				$epResult["episode"]
-			#end if
+    #if '' != $epLoc and None != $epLoc:
+			<span title="$epLoc" class="addQTip">$epResult["episode"]</span>
+    #else
+			$epResult['episode']
+    #end if
 		</td>
 		
-		#if $show.is_anime:
-			<td align="center">$epResult["absolute_number"]</td>
-		#end if
+    #if $show.is_anime:
+		<td align="center">$epResult['absolute_number']</td>
+    #end if
 
-		#if $scene:
-			<td align="center">
-				<input type="text" placeholder="<%=str(dfltSeas) + 'x' + str(dfltEpis)%>" size="6" maxlength="8"
-					class="sceneSeasonXEpisode form-control input-scene" data-for-season="$epResult["season"]" data-for-episode="$epResult["episode"]"
-					id="sceneSeasonXEpisode_$show.indexerid<%="_"+str(epResult["season"])+"_"+str(epResult["episode"])%>"
-					title="Change the value here if scene numbering differs from the indexer episode numbering"
-					#if $dfltEpNumbering:
-						value=""
-					#else
-						value="<%=str(scSeas) + 'x' + str(scEpis)%>"
-					#end if
-						style="padding: 0; text-align: center; max-width: 60px;" />
-			</td>
-		#elif $scene_anime:
-			<td align="center">
-				<input type="text" placeholder="<%=str(dfltAbsolute)%>" size="6" maxlength="8"
-					class="sceneAbsolute form-control input-scene" data-for-absolute="$epResult["absolute_number"]"
-					id="sceneAbsolute_$show.indexerid<%="_"+str(epResult["absolute_number"])%>"
-					title="Change the value here if scene absolute numbering differs from the indexer absolute numbering"
-					#if $dfltAbsNumbering:
-						value=""
-					#else
-						value="<%=str(scAbsolute)%>"
-					#end if
-						style="padding: 0; text-align: center; max-width: 60px;" />
-			</td>
-		#end if
+    #if $scene:
+		<td align="center">
+			<input type="text" placeholder="<%=str(dfltSeas) + 'x' + str(dfltEpis)%>" size="6" maxlength="8"
+				class="sceneSeasonXEpisode form-control input-scene" data-for-season="$epResult['season']" data-for-episode="$epResult['episode']"
+				id="sceneSeasonXEpisode_$show.indexerid<%='_'+str(epResult['season'])+'_'+str(epResult['episode'])%>"
+				title="Change the value here if scene numbering differs from the indexer episode numbering"
+        #if $dfltEpNumbering:
+				value=""
+        #else
+				value="<%=str(scSeas) + 'x' + str(scEpis)%>"
+        #end if
+				style="padding: 0; text-align: center; max-width: 60px;" />
+        </td>
+    #elif $scene_anime:
+        <td align="center">
+            <input type="text" placeholder="<%=str(dfltAbsolute)%>" size="6" maxlength="8"
+				class="sceneAbsolute form-control input-scene" data-for-absolute="$epResult['absolute_number']"
+				id="sceneAbsolute_$show.indexerid<%='_'+str(epResult['absolute_number'])%>"
+				title="Change the value here if scene absolute numbering differs from the indexer absolute numbering"
+        #if $dfltAbsNumbering:
+				value=""
+        #else
+				value="<%=str(scAbsolute)%>"
+        #end if
+				style="padding: 0; text-align: center; max-width: 60px;" />
+		</td>
+    #end if
 
 		<td class="col-name">
-			#if $epResult["description"] != "" and $epResult["description"] != None:
-				<img src="$sbRoot/images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_$show.indexerid<%="_" + str(epResult["season"]) + "_" + str(epResult["episode"])%>" />
-			#else:
-				<img src="$sbRoot/images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
-			#end if
-			$epResult["name"]
+    #if '' != $epResult['description'] and None != $epResult['description']:
+			<img src="$sbRoot/images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_$show.indexerid<%='_' + str(epResult['season']) + '_' + str(epResult['episode'])%>" />
+    #else:
+			<img src="$sbRoot/images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
+    #end if
+			$epResult['name']
 		</td>
 		
 		<td class="col-airdate">
-			<span class="${fuzzydate}">#if int($epResult['airdate']) == 1 then 'never' else $sbdatetime.sbdatetime.sbfdate($sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($epResult['airdate'],$show.airs,$show.network)))#</span>
+			<span class="${fuzzydate}">#if 1 == int($epResult['airdate']) then 'never' else $sbdatetime.sbdatetime.sbfdate($sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($epResult['airdate'], $show.airs, $show.network)))#</span>
 		</td>
 		
-		#if $sickbeard.USE_SUBTITLES and $show.subtitles:
-			<td class="col-subtitles" align="center">
-		#if $epResult["subtitles"]:
-		#for $sub_lang in subliminal.language.language_list($epResult["subtitles"].split(',')):
-        #if sub_lang.alpha2 != ""
-           	<img src="$sbRoot/images/flags/${sub_lang.alpha2}.png" width="16" height="11" alt="${sub_lang}" />
+    #if $sickbeard.USE_SUBTITLES and $show.subtitles:
+		<td class="col-subtitles" align="center">
+		#if $epResult['subtitles']:
+    		#for $sub_lang in subliminal.language.language_list($epResult['subtitles'].split(',')):
+                #if '' != sub_lang.alpha2
+			<img src="$sbRoot/images/flags/${sub_lang.alpha2}.png" width="16" height="11" alt="${sub_lang}" />
+		        #end if
+    		#end for
 		#end if
-		#end for
-		#end if
-			</td>
-		#end if
+		</td>
+    #end if
 		
-		#set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($epResult["status"]))
-			#if $curQuality != Quality.NONE:   
-				<td class="col-status">$statusStrings[$curStatus] <span class="quality $Quality.qualityStrings[$curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("RawHD TV", "RawHD").replace("HD TV", "HD720p")">$Quality.qualityStrings[$curQuality]</span></td>
-			#else:    
-				<td class="col-status">$statusStrings[$curStatus]</td>
-			#end if
-		
+    #set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($epResult['status']))
+    #if Quality.NONE != $curQuality:   
+		<td class="col-status">$statusStrings[$curStatus] <span class="quality $Quality.qualityStrings[$curQuality].replace('720p','HD720p').replace('1080p','HD1080p').replace('RawHD TV', 'RawHD').replace('HD TV', 'HD720p')">$Quality.qualityStrings[$curQuality]</span></td>
+    #else:    
+		<td class="col-status">$statusStrings[$curStatus]</td>
+    #end if
+    
 		<td class="col-search">
-			#if int($epResult["season"]) != 0:
-			#if ( int($epResult["status"]) in $Quality.SNATCHED or int($epResult["status"]) in $Quality.DOWNLOADED ) and $sickbeard.USE_FAILED_DOWNLOADS:
-				<a class="epRetry" id="<%=str(epResult["season"])+'x'+str(epResult["episode"])%>" name="<%=str(epResult["season"]) +"x"+str(epResult["episode"]) %>" href="retryEpisode?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
-			#else:
-				<a class="epSearch" id="<%=str(epResult["season"])+'x'+str(epResult["episode"])%>" name="<%=str(epResult["season"]) +"x"+str(epResult["episode"]) %>" href="searchEpisode?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/search16.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-			#end if
-			#end if
-			
-			#if $sickbeard.USE_SUBTITLES and $show.subtitles and len(set(str($epResult["subtitles"]).split(',')).intersection(set($subtitles.wantedLanguages()))) < len($subtitles.wantedLanguages()) and $epResult["location"]
-				<a class="epSubtitlesSearch" href="searchEpisodeSubtitles?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
-			#end if
+    #if 0 != int($epResult['season']):
+        #if (int($epResult['status']) in $Quality.SNATCHED or int($epResult['status']) in $Quality.DOWNLOADED) and $sickbeard.USE_FAILED_DOWNLOADS:
+			<a class="epRetry" id="<%=str(epResult['season'])+'x'+str(epResult['episode'])%>" name="<%=str(epResult['season']) +'x'+str(epResult['episode']) %>" href="retryEpisode?show=$show.indexerid&amp;season=$epResult['season']&amp;episode=$epResult['episode']"><img src="$sbRoot/images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
+        #else:
+			<a class="epSearch" id="<%=str(epResult['season'])+'x'+str(epResult['episode'])%>" name="<%=str(epResult['season']) +'x'+str(epResult['episode']) %>" href="searchEpisode?show=$show.indexerid&amp;season=$epResult['season']&amp;episode=$epResult['episode']"><img src="$sbRoot/images/search16.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+        #end if
+    #end if
+        
+    #if $sickbeard.USE_SUBTITLES and $show.subtitles and len(set(str($epResult['subtitles']).split(',')).intersection(set($subtitles.wantedLanguages()))) < len($subtitles.wantedLanguages()) and $epResult['location']
+			<a class="epSubtitlesSearch" href="searchEpisodeSubtitles?show=$show.indexerid&amp;season=$epResult['season']&amp;episode=$epResult['episode']"><img src="$sbRoot/images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+    #end if
 		</td>
 	</tr>
-
-	#end for
-	
+#end for
 </table>
 
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_bottom.tmpl')

--- a/gui/slick/interfaces/default/episodeView.tmpl
+++ b/gui/slick/interfaces/default/episodeView.tmpl
@@ -366,7 +366,7 @@
 			</td>
 
 			<td align="center" style="vertical-align: middle;">
-        #if $cur_result['imdb_id']:
+        #if sickbeard.USE_IMDB_INFO and $cur_result['imdb_id']:
 				<a href="<%= anon_url('http://www.imdb.com/title/', cur_result['imdb_id']) %>" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false" title="http://www.imdb.com/title/${cur_result['imdb_id']}"><img alt="[imdb]" height="16" width="16" src="$sbRoot/images/imdb.png" />
         #end if
 				<a href="<%= anon_url(sickbeard.indexerApi(cur_indexer).config['show_url'], cur_result['showid']) %>" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false" title="$sickbeard.indexerApi($cur_indexer).config['show_url']${cur_result['showid']}"><img alt="$sickbeard.indexerApi($cur_indexer).name" height="16" width="16" src="$sbRoot/images/$sickbeard.indexerApi($cur_indexer).config['icon']" /></a>
@@ -558,7 +558,7 @@
 					</a></span>
 
 					<span class="tvshowTitleIcons">
-        #if $cur_result['imdb_id']:
+        #if sickbeard.USE_IMDB_INFO and $cur_result['imdb_id']:
 						<a href="<%= anon_url('http://www.imdb.com/title/', cur_result['imdb_id']) %>" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false" title="http://www.imdb.com/title/${cur_result['imdb_id']}"><img alt="[imdb]" height="16" width="16" src="$sbRoot/images/imdb.png" />
         #end if
 						<a href="<%= anon_url(sickbeard.indexerApi(cur_indexer).config['show_url'], cur_result['showid']) %>" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false" title="$sickbeard.indexerApi($cur_indexer).config['show_url']${cur_result['showid']}"><img alt="$sickbeard.indexerApi($cur_indexer).name" height="16" width="16" src="$sbRoot/images/$sickbeard.indexerApi($cur_indexer).config['icon']" /></a>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -174,7 +174,7 @@ INDEXER_DEFAULT = None
 INDEXER_TIMEOUT = None
 SCENE_DEFAULT = False
 ANIME_DEFAULT = False
-USE_IMDB = False
+USE_IMDB_INFO = True
 PROVIDER_ORDER = []
 
 NAMING_MULTI_EP = False
@@ -525,7 +525,7 @@ def initialize(consoleLogging=True):
             AUTOPOSTPROCESSER_FREQUENCY, DEFAULT_AUTOPOSTPROCESSER_FREQUENCY, MIN_AUTOPOSTPROCESSER_FREQUENCY, \
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, SCENE_DEFAULT, BACKLOG_DAYS, ANIME_TREAT_AS_HDTV, \
-            COOKIE_SECRET, USE_IMDB
+            COOKIE_SECRET, USE_IMDB_INFO
 
         if __INITIALIZED__:
             return False
@@ -584,10 +584,18 @@ def initialize(consoleLogging=True):
         if CACHE_DIR:
             helpers.clearCache()
 
+        THEME_NAME = check_setting_str(CFG, 'GUI', 'theme_name', 'dark')
         GUI_NAME = check_setting_str(CFG, 'GUI', 'gui_name', 'slick')
         DEFAULT_HOME = check_setting_str(CFG, 'GUI', 'default_home', 'home')
-
-        THEME_NAME = check_setting_str(CFG, 'GUI', 'theme_name', 'dark')
+        USE_IMDB_INFO = bool(check_setting_int(CFG, 'GUI', 'use_imdb_info', 1))
+        HOME_SEARCH_FOCUS = bool(check_setting_int(CFG, 'General', 'home_search_focus', HOME_SEARCH_FOCUS))
+        SORT_ARTICLE = bool(check_setting_int(CFG, 'General', 'sort_article', 0))
+        FUZZY_DATING = bool(check_setting_int(CFG, 'GUI', 'fuzzy_dating', 0))
+        TRIM_ZERO = bool(check_setting_int(CFG, 'GUI', 'trim_zero', 0))
+        DATE_PRESET = check_setting_str(CFG, 'GUI', 'date_preset', '%x')
+        TIME_PRESET_W_SECONDS = check_setting_str(CFG, 'GUI', 'time_preset', '%I:%M:%S %p')
+        TIME_PRESET = TIME_PRESET_W_SECONDS.replace(u":%S", u"")
+        TIMEZONE_DISPLAY = check_setting_str(CFG, 'GUI', 'timezone_display', 'network')
 
         ACTUAL_LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
         # put the log dir inside the data dir, unless an absolute path
@@ -633,9 +641,6 @@ def initialize(consoleLogging=True):
         TRASH_REMOVE_SHOW = bool(check_setting_int(CFG, 'General', 'trash_remove_show', 0))
         TRASH_ROTATE_LOGS = bool(check_setting_int(CFG, 'General', 'trash_rotate_logs', 0))
 
-        HOME_SEARCH_FOCUS = bool(check_setting_int(CFG, 'General', 'home_search_focus', HOME_SEARCH_FOCUS))
-        SORT_ARTICLE = bool(check_setting_int(CFG, 'General', 'sort_article', 0))
-
         USE_API = bool(check_setting_int(CFG, 'General', 'use_api', 0))
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
 
@@ -664,7 +669,6 @@ def initialize(consoleLogging=True):
         INDEXER_TIMEOUT = check_setting_int(CFG, 'General', 'indexer_timeout', 20)
         ANIME_DEFAULT = bool(check_setting_int(CFG, 'General', 'anime_default', 0))
         SCENE_DEFAULT = bool(check_setting_int(CFG, 'General', 'scene_default', 0))
-        USE_IMDB = bool(check_setting_int(CFG, 'General', 'use_imdb', 0))
 
         PROVIDER_ORDER = check_setting_str(CFG, 'General', 'provider_order', '').split()
 
@@ -985,12 +989,7 @@ def initialize(consoleLogging=True):
         EPISODE_VIEW_SORT = check_setting_str(CFG, 'GUI', 'episode_view_sort', 'time')
         EPISODE_VIEW_DISPLAY_PAUSED = bool(check_setting_int(CFG, 'GUI', 'episode_view_display_paused', 0))
         EPISODE_VIEW_MISSED_RANGE = check_setting_int(CFG, 'GUI', 'episode_view_missed_range', 7)
-        FUZZY_DATING = bool(check_setting_int(CFG, 'GUI', 'fuzzy_dating', 0))
-        TRIM_ZERO = bool(check_setting_int(CFG, 'GUI', 'trim_zero', 0))
-        DATE_PRESET = check_setting_str(CFG, 'GUI', 'date_preset', '%x')
-        TIME_PRESET_W_SECONDS = check_setting_str(CFG, 'GUI', 'time_preset', '%I:%M:%S %p')
-        TIME_PRESET = TIME_PRESET_W_SECONDS.replace(u":%S", u"")
-        TIMEZONE_DISPLAY = check_setting_str(CFG, 'GUI', 'timezone_display', 'network')
+
         POSTER_SORTBY = check_setting_str(CFG, 'GUI', 'poster_sortby', 'name')
         POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1)
 
@@ -1451,7 +1450,6 @@ def save_config():
     new_config['General']['indexer_timeout'] = int(INDEXER_TIMEOUT)
     new_config['General']['anime_default'] = int(ANIME_DEFAULT)
     new_config['General']['scene_default'] = int(SCENE_DEFAULT)
-    new_config['General']['use_imdb'] = int(USE_IMDB)
     new_config['General']['provider_order'] = ' '.join(PROVIDER_ORDER)
     new_config['General']['version_notify'] = int(VERSION_NOTIFY)
     new_config['General']['auto_update'] = int(AUTO_UPDATE)
@@ -1812,20 +1810,21 @@ def save_config():
 
     new_config['GUI'] = {}
     new_config['GUI']['gui_name'] = GUI_NAME
-    new_config['GUI']['default_home'] = DEFAULT_HOME
     new_config['GUI']['theme_name'] = THEME_NAME
-    new_config['GUI']['home_layout'] = HOME_LAYOUT
-    new_config['GUI']['history_layout'] = HISTORY_LAYOUT
-    new_config['GUI']['display_show_specials'] = int(DISPLAY_SHOW_SPECIALS)
-    new_config['GUI']['episode_view_layout'] = EPISODE_VIEW_LAYOUT
-    new_config['GUI']['episode_view_display_paused'] = int(EPISODE_VIEW_DISPLAY_PAUSED)
-    new_config['GUI']['episode_view_sort'] = EPISODE_VIEW_SORT
-    new_config['GUI']['episode_view_missed_range'] = int(EPISODE_VIEW_MISSED_RANGE)
+    new_config['GUI']['default_home'] = DEFAULT_HOME
+    new_config['GUI']['use_imdb_info'] = int(USE_IMDB_INFO)
     new_config['GUI']['fuzzy_dating'] = int(FUZZY_DATING)
     new_config['GUI']['trim_zero'] = int(TRIM_ZERO)
     new_config['GUI']['date_preset'] = DATE_PRESET
     new_config['GUI']['time_preset'] = TIME_PRESET_W_SECONDS
     new_config['GUI']['timezone_display'] = TIMEZONE_DISPLAY
+    new_config['GUI']['home_layout'] = HOME_LAYOUT
+    new_config['GUI']['history_layout'] = HISTORY_LAYOUT
+    new_config['GUI']['display_show_specials'] = int(DISPLAY_SHOW_SPECIALS)
+    new_config['GUI']['episode_view_layout'] = EPISODE_VIEW_LAYOUT
+    new_config['GUI']['episode_view_sort'] = EPISODE_VIEW_SORT
+    new_config['GUI']['episode_view_display_paused'] = int(EPISODE_VIEW_DISPLAY_PAUSED)
+    new_config['GUI']['episode_view_missed_range'] = int(EPISODE_VIEW_MISSED_RANGE)
     new_config['GUI']['poster_sortby'] = POSTER_SORTBY
     new_config['GUI']['poster_sortdir'] = POSTER_SORTDIR
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -43,6 +43,7 @@ from sickbeard.providers.generic import GenericProvider
 from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickbeard import common
 
+
 def _downloadResult(result):
     """
     Downloads a result to the appropriate black hole folder.
@@ -87,6 +88,7 @@ def _downloadResult(result):
         newResult = False
 
     return newResult
+
 
 def snatchEpisode(result, endStatus=SNATCHED):
     """
@@ -164,12 +166,16 @@ def snatchEpisode(result, endStatus=SNATCHED):
             else:
                 curEpObj.status = Quality.compositeStatus(endStatus, result.quality)
 
-            sql_l.append(curEpObj.get_sql())
+            result = curEpObj.get_sql()
+            if None is not result:
+                sql_l.append(result)
 
         if curEpObj.status not in Quality.DOWNLOADED:
             notifiers.notify_snatch(curEpObj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    if len(sql_l) > 0:
+            curEpObj.show.load_imdb_info()
+
+    if 0 < len(sql_l):
         myDB = db.DBConnection()
         myDB.mass_action(sql_l)
 

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -198,7 +198,8 @@ class RecentSearchQueueItem(generic_queue.QueueItem):
                                  [common.UNAIRED, curDate])
 
         sql_l = []
-        wanted = show = None
+        show = None
+        wanted = False
 
         for sqlEp in sqlResults:
             try:
@@ -228,7 +229,7 @@ class RecentSearchQueueItem(generic_queue.QueueItem):
                 ep.status = (common.WANTED, common.SKIPPED)[ep.show.paused]
                 result = ep.get_sql()
                 if None is not result:
-                    sql_l.append(ep.get_sql())
+                    sql_l.append(result)
                     wanted |= (False, True)[common.WANTED == ep.status]
         else:
             logger.log(u'No unaired episodes marked wanted')

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -22,7 +22,6 @@ import traceback
 
 import sickbeard
 
-from lib.imdb import _exceptions as imdb_exceptions
 from sickbeard.common import SKIPPED, WANTED
 from sickbeard.tv import TVShow
 from sickbeard import exceptions, logger, ui, db
@@ -30,6 +29,7 @@ from sickbeard import generic_queue
 from sickbeard import name_cache
 from sickbeard.exceptions import ex
 from sickbeard.blackandwhitelist import BlackAndWhiteList
+
 
 class ShowQueue(generic_queue.GenericQueue):
     def __init__(self):
@@ -156,8 +156,7 @@ class ShowQueueActions:
              UPDATE: 'Update',
              FORCEUPDATE: 'Force Update',
              RENAME: 'Rename',
-             SUBTITLE: 'Subtitle',
-    }
+             SUBTITLE: 'Subtitle'}
 
 
 class ShowQueueItem(generic_queue.QueueItem):
@@ -340,15 +339,7 @@ class QueueItemAdd(ShowQueueItem):
             self._finishEarly()
             raise
 
-        if sickbeard.USE_IMDB:
-            logger.log(u'Retrieving show info from IMDb', logger.DEBUG)
-            try:
-                self.show.loadIMDbInfo()
-            except imdb_exceptions.IMDbError, e:
-                #todo Insert UI notification
-                logger.log(u'Something is wrong with IMDb api: ' + ex(e), logger.WARNING)
-            except Exception, e:
-                logger.log(u'Error loading IMDb info: ' + ex(e), logger.ERROR)
+        self.show.load_imdb_info()
 
         try:
             self.show.saveToDB()
@@ -473,6 +464,7 @@ class QueueItemRefresh(ShowQueueItem):
 
         self.inProgress = False
 
+
 class QueueItemRename(ShowQueueItem):
     def __init__(self, show=None):
         ShowQueueItem.__init__(self, ShowQueueActions.RENAME, show)
@@ -550,16 +542,6 @@ class QueueItemUpdate(ShowQueueItem):
             logger.log(u"Data retrieved from " + sickbeard.indexerApi(
                 self.show.indexer).name + " was incomplete, aborting: " + ex(e), logger.ERROR)
             return
-
-        if sickbeard.USE_IMDB:
-            logger.log(u'Retrieving show info from IMDb', logger.DEBUG)
-            try:
-                self.show.loadIMDbInfo()
-            except imdb_exceptions.IMDbError, e:
-                logger.log(u'Something is wrong with IMDb api: ' + ex(e), logger.WARNING)
-            except Exception, e:
-                logger.log(u'Error loading IMDb info: ' + ex(e), logger.ERROR)
-                logger.log(traceback.format_exc(), logger.DEBUG)
 
         try:
             self.show.saveToDB()

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -838,11 +838,11 @@ class TVShow(object):
         myDB = db.DBConnection()
         sqlResults = myDB.select("SELECT * FROM imdb_info WHERE indexer_id = ?", [self.indexerid])
 
-        if 0 == len(sqlResults):
-            logger.log(str(self.indexerid) + ': Unable to find IMDb show info in the database for [%s]' % self.name)
+        if 0 < len(sqlResults):
+            self.imdb_info = dict(zip(sqlResults[0].keys(), sqlResults[0]))
+        elif sickbeard.USE_IMDB_INFO:
+            logger.log(str(self.indexerid) + u': Unable to find IMDb show info in the database for [%s]' % self.name)
             return
-    
-        self.imdb_info = dict(zip(sqlResults[0].keys(), sqlResults[0]))
 
         self.dirty = False
         return True
@@ -893,7 +893,26 @@ class TVShow(object):
 
         self.status = getattr(myEp, 'status', '')
 
-    def loadIMDbInfo(self, imdbapi=None):
+    def load_imdb_info(self):
+
+        if not sickbeard.USE_IMDB_INFO:
+            return
+
+        from lib.imdb import _exceptions as imdb_exceptions
+
+        logger.log(u'Retrieving show info from IMDb', logger.DEBUG)
+        try:
+            self._get_imdb_info()
+        except imdb_exceptions.IMDbError, e:
+            logger.log(u'Something is wrong with IMDb api: ' + ex(e), logger.WARNING)
+        except Exception, e:
+            logger.log(u'Error loading IMDb info: ' + ex(e), logger.ERROR)
+            logger.log(u'' + traceback.format_exc(), logger.DEBUG)
+
+    def _get_imdb_info(self):
+
+        if not self.imdbid:
+            return
 
         imdb_info = {'imdb_id': self.imdbid,
                      'title': '',
@@ -906,64 +925,62 @@ class TVShow(object):
                      'certificates': [],
                      'rating': '',
                      'votes': '',
-                     'last_update': ''
-        }
+                     'last_update': ''}
 
-        if self.imdbid:
-            logger.log(str(self.indexerid) + u": Loading show info from IMDb")
+        i = imdb.IMDb()
+        imdbTv = i.get_movie(str(re.sub('[^0-9]', '', self.imdbid)))
 
-            i = imdb.IMDb()
-            imdbTv = i.get_movie(str(re.sub("[^0-9]", "", self.imdbid)))
-
-            for key in filter(lambda x: x.replace('_', ' ') in imdbTv.keys(), imdb_info.keys()):
-                # Store only the first value for string type
-                if type(imdb_info[key]) == type('') and type(imdbTv.get(key)) == type([]):
-                    imdb_info[key] = imdbTv.get(key.replace('_', ' '))[0]
-                else:
-                    imdb_info[key] = imdbTv.get(key.replace('_', ' '))
-
-            # Filter only the value
-            if imdb_info['runtimes']:
-                imdb_info['runtimes'] = re.search('\d+', imdb_info['runtimes']).group(0)
+        for key in filter(lambda x: x.replace('_', ' ') in imdbTv.keys(), imdb_info.keys()):
+            # Store only the first value for string type
+            if type(imdb_info[key]) == type('') and type(imdbTv.get(key)) == type([]):
+                imdb_info[key] = imdbTv.get(key.replace('_', ' '))[0]
             else:
-                imdb_info['runtimes'] = self.runtime
+                imdb_info[key] = imdbTv.get(key.replace('_', ' '))
 
-            if imdb_info['akas']:
-                imdb_info['akas'] = '|'.join(imdb_info['akas'])
-            else:
-                imdb_info['akas'] = ''
+        # Filter only the value
+        if imdb_info['runtimes']:
+            imdb_info['runtimes'] = re.search('\d+', imdb_info['runtimes']).group(0)
+        else:
+            imdb_info['runtimes'] = self.runtime
 
-            # Join all genres in a string
-            if imdb_info['genres']:
-                imdb_info['genres'] = '|'.join(imdb_info['genres'])
-            else:
-                imdb_info['genres'] = ''
+        if imdb_info['akas']:
+            imdb_info['akas'] = '|'.join(imdb_info['akas'])
+        else:
+            imdb_info['akas'] = ''
 
-            # Get only the production country certificate if any
-            if imdb_info['certificates'] and imdb_info['countries']:
-                dct = {}
-                try:
-                    for item in imdb_info['certificates']:
-                        dct[item.split(':')[0]] = item.split(':')[1]
+        # Join all genres in a string
+        if imdb_info['genres']:
+            imdb_info['genres'] = '|'.join(imdb_info['genres'])
+        else:
+            imdb_info['genres'] = ''
 
-                    imdb_info['certificates'] = dct[imdb_info['countries']]
-                except:
-                    imdb_info['certificates'] = ''
+        # Get only the production country certificate if any
+        if imdb_info['certificates'] and imdb_info['countries']:
+            dct = {}
+            try:
+                for item in imdb_info['certificates']:
+                    dct[item.split(':')[0]] = item.split(':')[1]
 
-            else:
+                imdb_info['certificates'] = dct[imdb_info['countries']]
+            except:
                 imdb_info['certificates'] = ''
 
-            if imdb_info['country_codes']:
-                imdb_info['country_codes'] = '|'.join(imdb_info['country_codes'])
-            else:
-                imdb_info['country_codes'] = ''
+        else:
+            imdb_info['certificates'] = ''
 
-            imdb_info['last_update'] = datetime.date.today().toordinal()
+        if imdb_info['country_codes']:
+            imdb_info['country_codes'] = '|'.join(imdb_info['country_codes'])
+        else:
+            imdb_info['country_codes'] = ''
 
-            # Rename dict keys without spaces for DB upsert
-            self.imdb_info = dict(
-                (k.replace(' ', '_'), k(v) if hasattr(v, 'keys') else v) for k, v in imdb_info.items())
-            logger.log(str(self.indexerid) + u": Obtained info from IMDb ->" + str(self.imdb_info), logger.DEBUG)
+        imdb_info['last_update'] = datetime.date.today().toordinal()
+
+        # Rename dict keys without spaces for DB upsert
+        self.imdb_info = dict(
+            (k.replace(' ', '_'), k(v) if hasattr(v, 'keys') else v) for k, v in imdb_info.items())
+        logger.log(str(self.indexerid) + u': Obtained info from IMDb ->' + str(self.imdb_info), logger.DEBUG)
+
+        logger.log(str(self.indexerid) + u': Parsed latest IMDb show info for [%s]' % self.name)
 
     def nextEpisode(self):
         logger.log(str(self.indexerid) + ": Finding the episode which airs next", logger.DEBUG)
@@ -1172,12 +1189,12 @@ class TVShow(object):
 
         helpers.update_anime_support()
 
-        if self.imdbid:
-            controlValueDict = {"indexer_id": self.indexerid}
+        if sickbeard.USE_IMDB_INFO and self.imdbid:
+            controlValueDict = {'indexer_id': self.indexerid}
             newValueDict = self.imdb_info
 
             myDB = db.DBConnection()
-            myDB.upsert("imdb_info", newValueDict, controlValueDict)
+            myDB.upsert('imdb_info', newValueDict, controlValueDict)
 
     def __str__(self):
         toReturn = ""

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3354,7 +3354,7 @@ class ConfigGeneral(Config):
                     handle_reverse_proxy=None, home_search_focus=None, sort_article=None, auto_update=None, notify_on_update=None,
                     proxy_setting=None, proxy_indexers=None, anon_redirect=None, git_path=None, git_remote=None, calendar_unprotected=None,
                     fuzzy_dating=None, trim_zero=None, date_preset=None, date_preset_na=None, time_preset=None,
-                    indexer_timeout=None, use_imdb=None, rootDir=None, theme_name=None, default_home=None):
+                    indexer_timeout=None, rootDir=None, theme_name=None, default_home=None, use_imdb_info=None):
 
         results = []
 
@@ -3372,6 +3372,7 @@ class ConfigGeneral(Config):
         config.change_UPDATE_FREQUENCY(update_frequency)
         sickbeard.LAUNCH_BROWSER = config.checkbox_to_value(launch_browser)
         sickbeard.HOME_SEARCH_FOCUS = config.checkbox_to_value(home_search_focus)
+        sickbeard.USE_IMDB_INFO = config.checkbox_to_value(use_imdb_info)
         sickbeard.SORT_ARTICLE = config.checkbox_to_value(sort_article)
         sickbeard.CPU_PRESET = cpu_preset
         sickbeard.ANON_REDIRECT = anon_redirect
@@ -3409,9 +3410,6 @@ class ConfigGeneral(Config):
 
         if indexer_timeout:
             sickbeard.INDEXER_TIMEOUT = config.to_int(indexer_timeout)
-
-        if use_imdb:
-            sickbeard.USE_IMDB = config.checkbox_to_value(use_imdb)
 
         if time_preset:
             sickbeard.TIME_PRESET_W_SECONDS = time_preset


### PR DESCRIPTION
Change to reduce the time taken to "Update shows" with show data.

Add "Enable IMDb info" option to config/General/Interface.
Change to not display IMDb info on UI when "Enable IMDb info" is disabled.
Change genre tags on displayShow page to link to IMDb instead of Trakt.
Change to reduce the time taken to "Update shows" with show data.
Change when IMDb info is updated...
a) stop updating the IMDb info during the scheduled daily update for every show.
b) update the IMDb info for a show after snatching an episode for it.

Develop changes...
Fix being able to actually turn IMDb off when it has been turned on.
Remove IMDb option from General Settings.
Change IMDb option to enable by default now the slow operation has been eliminated from processes.