### PR TITLE
Add indication of shows with never aired episodes and other changes to...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,13 @@
 * Change the episodes downloaded stat to display e.g. 2843 / 2844 as 99.9% instead of rounding to 100%
 * Change 'never' episode row color away from blue on Display Show page when indexer airdate is not defined
 * Add tint to archived episode row colour to differentiate it from downloaded episodes on the Display Show page
+* Add indication of shows with never aired episodes on Episode Overview page
+* Add "Collapse" button and visuals for Expanding... and Collapsing... states
+* Add the number of episodes marked with the status being queried to Episode Overview page
+* Add indication of shows with never aired episodes on Episode Overview page
+* Change to separate "Set as wanted" to prevent disaster selection on Episode Overview page
+* Remove restriction to not display snatched eps link in footer on Episode Overview page
+* Change the shows episodes count text colour to visually separete from year numbers at the end of show names
 * Fix release group not recognised from manually downloaded filename
 
 [develop changelog]

--- a/gui/slick/css/dark.css
+++ b/gui/slick/css/dark.css
@@ -382,11 +382,13 @@ ul.tags li a{
 	border:1px solid #111
 }
 
+.sickbeardTable tr.header td,
 .sickbeardTable th{
 	color:#fff;
 	background-color:#15528F
 }
 
+.sickbeardTable tr.header td,
 .sickbeardTable th,
 .sickbeardTable td{
 	border-top:1px solid #222;

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1324,6 +1324,7 @@ span.snatched b{
 	clear:both
 }
 
+.sickbeardTable tr.header td,
 .sickbeardTable th{
 	color:#fff;
 	text-align:center;
@@ -1331,11 +1332,16 @@ span.snatched b{
 	white-space:nowrap
 }
 
-.sickbeardTable th, 
+.sickbeardTable tr.header td,
+.sickbeardTable th,
 .sickbeardTable td{
 	border-top:1px solid #fff;
 	border-left:1px solid #fff;
 	padding:4px
+}
+
+.sickbeardTable tr.header td{
+	padding:4px 8px
 }
 
 th.row-seasonheader{
@@ -2247,6 +2253,7 @@ div.metadataDiv .disabled{
 manage*.tmpl
 ========================================================================== */
 
+.sickbeardTable tr.header td,
 .manageTable th{
 	white-space:normal;
 	line-height:24px
@@ -2298,6 +2305,11 @@ td.tableright{
 
 a.whitelink{
 	color:#fff
+}
+
+input.get_more_eps,
+input.get_less_eps{
+	display:none
 }
 
 /* =======================================================================

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -56,11 +56,8 @@
 (
 '',
 ' (<span class="footerhighlight">+%s</span> snatched)'\
-% (
-    str(ep_snatched),
-    '<a href="%s/manage/episodeStatuses?whichStatus=2" title="View overview of snatched episodes">%s</a>'\
-        % (localRoot, str(ep_snatched))
-  )['Episode Overview' != localheader]
+% '<a href="%s/manage/episodeStatuses?whichStatus=2" title="View overview of snatched episodes">%s</a>'
+    % (localRoot, str(ep_snatched))
 )[0 < ep_snatched]
 %>&nbsp;/&nbsp;<span class="footerhighlight">$ep_total</span> episodes downloaded $ep_percentage
 		| recent search: <span class="footerhighlight"><%= str(sickbeard.recentSearchScheduler.timeLeft()).split('.')[0] %></span>

--- a/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
+++ b/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
@@ -16,70 +16,96 @@
 	<h1 class="title">$title</h1>
 #end if
 
-#if not $whichStatus or ($whichStatus and not $ep_counts):
+#if not $whichStatus or ($whichStatus and not $ep_counts)
 
-#if $whichStatus:
-	<h3>None of your episodes have status <span class="grey-text">$common.statusStrings[$int($whichStatus)]</span></h3>
-#end if
+    #if $whichStatus:
+	<h3>no episodes have status <span class="grey-text">$common.statusStrings[$int($whichStatus)].lower()</span></h3>
+    #end if
 
-<form action="$sbRoot/manage/episodeStatuses" method="get">
-	Manage episodes with status <select name="whichStatus" class="form-control form-control-inline input-sm">
-#for $curStatus in [$common.SKIPPED, $common.UNKNOWN, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
-	<option value="$curStatus">$common.statusStrings[$curStatus]</option>
-#end for
-	</select>
-	<input class="btn btn-inline" type="submit" value="Manage" /> 
-</form>
+	<form action="$sbRoot/manage/episodeStatuses" method="get">
+
+		Manage episodes with status
+		<select name="whichStatus" class="form-control form-control-inline input-sm" style="margin:0 10px">
+
+    #for $curStatus in [$common.SKIPPED, $common.UNKNOWN, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
+			<option value="$curStatus">$common.statusStrings[$curStatus]</option>
+    #end for
+
+		</select>
+		<input class="btn btn-inline" type="submit" value="Manage">
+	</form>
 
 #else
+
+    #if $whichStatus in ($common.ARCHIVED, $common.IGNORED, $common.SNATCHED):
+        #set $row_class = 'good'
+    #else
+        #set $row_class = $common.Overview.overviewStrings[$whichStatus]
+    #end if
+
+    #set $statusList = [$common.SKIPPED, $common.ARCHIVED, $common.IGNORED]
+    #if $int($whichStatus) in $statusList
+        $statusList.remove($int($whichStatus))
+    #end if
+
+    #if $int($whichStatus) in [$common.SNATCHED, $common.SNATCHED_PROPER]
+        $statusList.append($common.FAILED)
+    #end if
 
 <script type="text/javascript" src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
 
-<form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
-<input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus" />
+	<form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
+		<input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus">
 
-<h3>${len($sorted_show_ids)} Shows containing <span class="grey-text">$common.statusStrings[$int($whichStatus)]</span> episodes</h3>
+		<h3><span class="grey-text">$ep_count</span> episode#echo ('s', '')[1 == $ep_count]# marked <span class="grey-text">$common.statusStrings[$int($whichStatus)].lower()</span> in <span class="grey-text">${len($sorted_show_ids)}</span> show#echo ('s', '')[1 == len($sorted_show_ids)]#</h3>
 
-#if $whichStatus in ($common.ARCHIVED, $common.IGNORED, $common.SNATCHED):
-    #set $row_class = 'good'
-#else
-    #set $row_class = $common.Overview.overviewStrings[$whichStatus]
-#end if
-<input type="hidden" id="row_class" value="$row_class" />
+		<input type="hidden" id="row_class" value="$row_class">
 
-<div class="form-group">
-	Set checked shows/episodes to <select name="newStatus" class="form-control form-control-inline input-sm">
-#set $statusList = [$common.SKIPPED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]
-#if $int($whichStatus) in $statusList
-    $statusList.remove($int($whichStatus))
-#end if
+		<div class="form-group">
+			<span>Set checked shows/episodes to</span>
+			<select name="newStatus" class="form-control form-control-inline input-sm" style="margin:0 10px 0 5px">
+    #for $curStatus in $statusList:
+				<option value="$curStatus">$common.statusStrings[$curStatus]</option>
+    #end for
+			</select>
+			<input class="btn btn-inline go" type="submit" value="Go">
 
-#if $int($whichStatus) in [$common.SNATCHED, $common.SNATCHED_PROPER]
-    $statusList.append($common.FAILED)
-#end if
+			<span class="red-text" style="margin:0 0 0 30px">Override checked status to</span>
+			<select name="wantedStatus" class="form-control form-control-inline input-sm" style="margin:0 10px 0 5px">
+				<option value="$common.UNKNOWN">nothing</option>
+				<option value="$common.WANTED">$common.statusStrings[$common.WANTED]</option>
+			</select>
+			<input class="btn btn-inline go" type="submit" value="Go">
+		</div>
 
-#for $curStatus in $statusList:
-	<option value="$curStatus">$common.statusStrings[$curStatus]</option>
-#end for
-	</select>
-	<input class="btn btn-inline go" type="submit" value="Go" />
-</div>
+		<div class="form-group">
+			<input type="button" class="btn btn-xs selectAllShows" value="Select all">
+			<input type="button" class="btn btn-xs unselectAllShows" value="Clear all">
+			<input type="button" class="btn btn-xs expandAll" value="Expand All Shows">
+		</div>
 
-<div class="form-group">
-	<input type="button" class="btn btn-xs selectAllShows" value="Select all"> 
-	<input type="button" class="btn btn-xs unselectAllShows" value="Clear all">
-	<input type="button" class="btn btn-xs expandAll" value="Expand All Shows">
-</div>
-
-<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0">
-#for $cur_indexer_id in $sorted_show_ids:
-	<tr id="$cur_indexer_id">
-		<th><input type="checkbox" class="allCheck" id="allCheck-$cur_indexer_id" name="$cur_indexer_id-all" /></th>
-		<th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_indexer_id">$show_names[$cur_indexer_id]</a> ($ep_counts[$cur_indexer_id]) <input type="button" class="pull-right get_more_eps btn" id="$cur_indexer_id" value="Expand" /></th>
-	</tr>
-#end for
-</table>
-</form>
+		<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0">
+			<thead></thead>
+			<tbody>
+    #for $cur_indexer_id in $sorted_show_ids:
+        #if 0 == int($never_counts[$cur_indexer_id])
+            #set $output = '%d' % $ep_counts[$cur_indexer_id]
+        #elif $ep_counts[$cur_indexer_id] != $never_counts[$cur_indexer_id]
+            #set $diff = $ep_counts[$cur_indexer_id] - $never_counts[$cur_indexer_id]
+            #set $output = '%d' % $diff + ('', (' episode%s plus %s never with an airdate' % (('s', '')[1 == $ep_counts[$cur_indexer_id]], $never_counts[$cur_indexer_id])))[0 < $never_counts[$cur_indexer_id]]
+        #else
+            #set $output = '%s never with an airdate' % (('all %s %ss', '%s %s')[1 == $ep_counts[$cur_indexer_id]] % ($ep_counts[$cur_indexer_id], 'episode'))
+        #end if
+				<tr id="$cur_indexer_id" class="header">
+					<td><input type="checkbox" class="allCheck" id="allCheck-$cur_indexer_id" name="$cur_indexer_id-all"></td>
+					<td colspan="2" style="width:100%;text-align:left">
+						<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_indexer_id">$show_names[$cur_indexer_id]</a> <span style="color:#999">($output)</span><input type="button" class="pull-right get_more_eps btn" id="$cur_indexer_id-more" value="Expand"><input type="button" class="pull-right get_less_eps btn" id="$cur_indexer_id-less" value="Collapse">
+					</td>
+				</tr>
+    #end for
+			</tbody>
+		</table>
+	</form>
 
 #end if
 


### PR DESCRIPTION
...the Episode Overview page.

Add "Collapse" button and visuals for Expanding... and Collapsing... states.
Add the number of episodes marked with the status being queried.
Add indication of shows with never aired episodes.
Change to separate "Set as wanted" to prevent disaster selection.
Remove restriction to not display snatched episodes link in footer.
Change the shows episodes count text colour to visually separete from year numbers at the end of show names.