### PR TITLE
Change to adjust alignment of season label text when next to select combo.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,7 +87,6 @@
 * Change Special link moved from "Season" line to "Specials" line on displayShow
 * Change code re-factored in readiness for live option switching, clean up and add closures of html tables
 * Add show overview from indexers to the database
-* Fix genre tags on displayShow when imdb is disabled
 
 [develop changelog]
 * Fix traceback error when using the menu item Manage/Update Kodi
@@ -106,6 +105,10 @@
 * Add some tooltips to bottom show details for clarity on displayShow
 * Change red text on blue tag to white text on red tag to improve readability of invalid locations on displayShow
 * Change glyph to right side of "Show/Hide episodes" button text to improve visual when toggling button on displayShow
+* Change to adjust alignment of season label text when next to select combo
+* Change display genres sourced from indexers in labels underneath the show title on displayShow, remove the tag image
+* Change IMDb genre links to have the tag image applied to the link making it an easier target to click and also visually different from indexer genres
+* Fix scene anime html id construction in line with plot_info
 
 ### 0.7.2 (2015-03-10 17:05:00 UTC)
 

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -198,14 +198,14 @@ inc_top.tmpl
 	background:#fff url("../css/lib/images/ui-bg_flat_0_ffffff_40x100.png") 50% 50% repeat-x
 }
 
-.ui-state-default, 
+.ui-state-default,
 .ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default{
 	background:#fff;
 	border:1px solid #CCC
 }
 
-.ui-state-hover, 
+.ui-state-hover,
 .ui-widget-content .ui-state-hover,
 .ui-widget-header .ui-state-hover,
 .ui-state-focus,
@@ -214,19 +214,19 @@ inc_top.tmpl
 	background:#fff
 }
 
-.ui-state-active, 
+.ui-state-active,
 .ui-widget-content .ui-state-active,
 .ui-widget-header .ui-state-active{
 	background:#F7F7F7
 }
 
-.ui-state-highlight, 
+.ui-state-highlight,
 .ui-widget-content .ui-state-highlight,
 .ui-widget-header .ui-state-highlight{
 	background:#fbf9ee url("../css/lib/images/ui-bg_glass_55_fbf9ee_1x400.png") 50% 50% repeat-x
 }
 
-.ui-state-error, 
+.ui-state-error,
 .ui-widget-content .ui-state-error,
 .ui-widget-header .ui-state-error{
 	background:#fef1ec url("../css/lib/images/ui-bg_glass_95_fef1ec_1x400.png") 50% 50% repeat-x
@@ -745,7 +745,7 @@ home.tmpl
 	background-image:linear-gradient(to left, rgba(223, 218, 207, 1), rgba(223, 218, 207, 0))
 }
 
-.show-table{	
+.show-table{
 	text-align:center;
 	vertical-align:middle;
 	width:33%
@@ -1067,7 +1067,7 @@ home_postprocess.tmpl
 
 
 /* =======================================================================
-displayShow.tmpl 
+displayShow.tmpl
 ========================================================================== */
 body#display-show.back-art {
 	color:#fff
@@ -1174,6 +1174,14 @@ body#display-show .back-art .sickbeardTable{
 	height:70px
 }
 
+#details-right .details-seasons{
+	margin-top:3px
+}
+
+#details-right .combo-seasons{
+	line-height:30px
+}
+
 #details-bottom{
 	display:inline-block;
 	width:100%
@@ -1241,13 +1249,14 @@ body#display-show .back-art .sickbeardTable{
 }
 
 #details-top .label{
-	padding:3px 4px 3px 22px;
-	background:url(../images/tag.png) no-repeat scroll 4px 3px;
+	padding:3px 4px;
 	cursor:default
 }
 
 #details-top .label a,
 #details-top .label a:hover{
+	padding:3px 4px 3px 21px;
+	background:transparent url(../images/tag.png) no-repeat scroll 3px 3px;
 	color:#fff;
 	text-decoration:none
 }
@@ -3453,7 +3462,7 @@ div.formpaginate .prev, div.formpaginate .next{
 #customQualityWrapper div.component-group-desc{
 	float:left;
 	width:165px
-}	
+}
 
 #customQualityWrapper div.component-group-desc p{
 	width:85%;

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -139,11 +139,11 @@ $displayshowlist.append('\t\t\t<optgroup label="%s">' % $curShowType)
 						<span class="details-info">#if sickbeard.DISPLAY_SHOW_SPECIALS#<a href="#season-0">View</a><span style="margin:0 10px">-</span>#end if#<a class="inner" href="$sbRoot/toggleDisplayShowSpecials/?show=$show.indexerid">#echo ('Show', 'Hide')[sickbeard.DISPLAY_SHOW_SPECIALS]#</a></span>
     #end if
 					</div>
-
-					<div style="margin-top:3px">
-						<span class="details-title">Season</span>
+    #set $many_seasons = 12 < len($seasonResults)
+					<div class="details-seasons">
+						<span class="details-title#echo ('', ' combo-seasons')[$many_seasons]#">Season</span>
 						<span class="details-info">
-    #if 12 < (len($seasonResults)):
+    #if $many_seasons:
 							<select id="seasonJump" class="form-control form-control-inline input-sm">
 								<option value="jump">Jump to season</option>
         #for $seasonNum in $seasonResults:
@@ -171,8 +171,8 @@ $displayshowlist.append('\t\t\t<optgroup label="%s">' % $curShowType)
 						<h2 class="title" id="scene_exception_$show.indexerid"><span>$show.name</span></h2>
 #if not $sickbeard.USE_IMDB_INFO or not $show.imdbid
     #if $show.genre:
-        #for $genre in $show.genre[1:-1].replace('Science-Fiction','Sci-Fi').split('|')
-						<span class="label"><a href="<%= anon_url('http://www.imdb.com/search/title?at=0&genres=', genre.lower().replace('-','_'),'&amp;sort=moviemeter,asc&amp;title_type=tv_series') %>" target="_blank" title="View other popular $genre shows on imdb.com">$genre</a></span>
+        #for $genre in $show.genre[1:-1].split('|')
+						<span class="label">$genre</span>
         #end for
     #end if
 #end if
@@ -491,7 +491,7 @@ $displayshowlist.append('\t\t\t<optgroup label="%s">' % $curShowType)
 		<td align="center">
 			<input type="text" placeholder="#echo '%sx%s' % ($dfltSeas, $dfltEpis)#" size="6" maxlength="8"
 				class="sceneSeasonXEpisode form-control input-scene" data-for-season="$epResult['season']" data-for-episode="$epResult['episode']"
-				id="sceneSeasonXEpisode_#echo '%s_%s_%s' % ($show.indexerid, $epResult['season'], $epResult['episode'])#"
+				id="#echo 'sceneSeasonXEpisode_%s_%s_%s' % ($show.indexerid, $epResult['season'], $epResult['episode'])#"
 				title="Change the value here if scene numbering differs from the indexer episode numbering"
         #if ($epResult['season'], $epResult['episode']) in $scene_numbering:
             #set $scSeas, $scEpis = $scene_numbering[($epResult['season'], $epResult['episode'])]
@@ -506,7 +506,7 @@ $displayshowlist.append('\t\t\t<optgroup label="%s">' % $curShowType)
 		<td align="center">
 			<input type="text" placeholder="$dfltAbsolute" size="6" maxlength="8"
 				class="sceneAbsolute form-control input-scene" data-for-absolute="$epResult['absolute_number']"
-				id="sceneAbsolute_$show.indexerid_$epResult['absolute_number']"
+				id="#echo 'sceneAbsolute_%s_%s' % ($show.indexerid, $epResult['absolute_number'])#"
 				title="Change the value here if scene absolute numbering differs from the indexer absolute numbering"
         #if $epResult['absolute_number'] in $scene_absolute_numbering:
 				value="$scene_absolute_numbering[$epResult['absolute_number']]"


### PR DESCRIPTION
Change display genres sourced from indexers in labels underneath the show title on displayShow, remove the tag image.
Change IMDb genre links to have the tag image applied to the link making it an easier target to click and also visually different from indexer genres.
Fix scene anime html id construction in line with plot_info.