### PR TITLE
Fix XEM Exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,7 @@
 * Fix correctly initialise IMDb id loaded from db
 * Fix loading shows from the DB that have NULL IMDb id
 * Change order of snatched provider images to chronological on History layout compact and add ordinal indicators in the tooltips
+* Fix XEM Exceptions in case of bad data from XEM
 
 ### 0.7.2 (2015-03-10 17:05:00 UTC)
 

--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -317,7 +317,10 @@ def _xem_exceptions_fetcher():
                 continue
 
             for indexerid, names in parsedJSON['data'].items():
-                xem_exception_dict[int(indexerid)] = names
+                try:
+                    xem_exception_dict[int(indexerid)] = names
+                except:
+                    continue
 
         setLastRefresh('xem')
 


### PR DESCRIPTION
Prevent a crash/hangup of SickGear in case of wrong data from XEM