### PR TITLE
Fix Backlog scheduler Init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-### 0.x.x (2015-xx-xx xx:xx:xx UTC)
+﻿### 0.x.x (2015-xx-xx xx:xx:xx UTC)
 
 * Add ToTV provider
+* Fix Backlog scheduler initialization and change backlog frequency from minutes to days
 
 
 ### 0.8.1 (2015-04-15 04:16:00 UTC)

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -95,7 +95,7 @@
 								<span class="component-title">Backlog search frequency</span>
 								<span class="component-desc">
 									<input type="text" name="backlog_frequency" value="$sickbeard.BACKLOG_FREQUENCY" class="form-control input-sm input75">
-									<p>minutes between searches (minimum $sickbeard.MIN_BACKLOG_FREQUENCY)</p>
+									<p>days between full backlog searches (min $sickbeard.MIN_BACKLOG_FREQUENCY, default $sickbeard.DEFAULT_BACKLOG_FREQUENCY, max $sickbeard.MAX_BACKLOG_FREQUENCY)</p>
 								</span>
 							</label>
 						</div>

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -62,6 +62,7 @@
 %>&nbsp;/&nbsp;<span class="footerhighlight">$ep_total</span> episodes downloaded $ep_percentage
 		| recent search: <span class="footerhighlight"><%= str(sickbeard.recentSearchScheduler.timeLeft()).split('.')[0] %></span>
 		| backlog search: <span class="footerhighlight"><%= str(sickbeard.backlogSearchScheduler.timeLeft()).split('.')[0] %></span>
+		| full backlog: <span class="footerhighlight"><%= sbdatetime.sbdatetime.sbfdate(sickbeard.backlogSearchScheduler.nextRun()) %></span>
 #slurp
 	</div>
 </footer>

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -164,13 +164,9 @@ def change_RECENTSEARCH_FREQUENCY(freq):
 
 
 def change_BACKLOG_FREQUENCY(freq):
-    sickbeard.BACKLOG_FREQUENCY = to_int(freq, default=sickbeard.DEFAULT_BACKLOG_FREQUENCY)
+    sickbeard.BACKLOG_FREQUENCY = minimax(freq, sickbeard.DEFAULT_BACKLOG_FREQUENCY, sickbeard.MIN_BACKLOG_FREQUENCY, sickbeard.MAX_BACKLOG_FREQUENCY)
 
-    sickbeard.MIN_BACKLOG_FREQUENCY = sickbeard.get_backlog_cycle_time()
-    if sickbeard.BACKLOG_FREQUENCY < sickbeard.MIN_BACKLOG_FREQUENCY:
-        sickbeard.BACKLOG_FREQUENCY = sickbeard.MIN_BACKLOG_FREQUENCY
-
-    sickbeard.backlogSearchScheduler.cycleTime = datetime.timedelta(minutes=sickbeard.BACKLOG_FREQUENCY)
+    sickbeard.backlogSearchScheduler.action.cycleTime = sickbeard.BACKLOG_FREQUENCY
 
 
 def change_UPDATE_FREQUENCY(freq):
@@ -741,3 +737,7 @@ class ConfigMigrator():
     def _migrate_v9(self):
         sickbeard.PUSHBULLET_ACCESS_TOKEN = check_setting_str(self.config_obj, 'Pushbullet', 'pushbullet_api', '')
         sickbeard.PUSHBULLET_DEVICE_IDEN = check_setting_str(self.config_obj, 'Pushbullet', 'pushbullet_device', '')
+
+    def _migrate_v10(self):
+        # reset backlog frequency to default
+        sickbeard.BACKLOG_FREQUENCY = sickbeard.DEFAULT_BACKLOG_FREQUENCY

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -48,7 +48,7 @@ class BacklogSearcher:
     def __init__(self):
 
         self._lastBacklog = self._get_lastBacklog()
-        self.cycleTime = sickbeard.BACKLOG_FREQUENCY / 60 / 24
+        self.cycleTime = sickbeard.BACKLOG_FREQUENCY
         self.lock = threading.Lock()
         self.amActive = False
         self.amPaused = False


### PR DESCRIPTION
Fix the limited backlog to execute as and when expected and in line with SickBeard.

The *backlog scheduled frequency* is the higher of either 12 hours or 2 x the "Recent search frequency" + 7 minutes.

On application startup and every *backlog scheduled frequency* the backlog will either ...
a) do a full run if the number of days passed since the full backlog has reached the setting(1)...
b) do a limited run if the number of days passed since the full backlog is less than setting(1)...
... (1) "***Backlog search frequency***" in Search Settings.

Change the default full "Backlog search frequency" to 21 days within a range of 2 - 35 (see Search Settings).