### PR TITLE
Fix issue changing a custom show list group name that is in use.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,11 +25,21 @@
 * Fix display of search status for an alternative release after episode is manually set to "Failed" on the Display Show page
 * Change handle more varieties of media quality
 * Change to prevent another scheduled search when one of the same type is already running
-* Add custom show lists to home page
 * Change travis to new container builds for faster unit testing
 * Add handling for shows that do not have a total number of episodes
 * Add support for country network image files to the Show List view
+* Add General Config/Interface/"Group show list shows into:"... to divide shows into groups on the Show List page
+* Change Show List progress bar code, smaller page load, efficient use of js render engine
 * Change values used for date sorting on home page and episode view for improved compatibility with posix systems
+
+[develop changelog]
+Fix issue changing a custom show list group name that is in use. The bug resulted in the db containing stale group names
+but worse, orphaned shows disappeared from the Show List page entirely. Changed texts to describe this feature more
+clearly from tag to group names. Repositioned this feature on the add show, edit show, and config pages. Change the drop
+down select to dynamically hide/show the list of group names and change the respectively selected help texts. Change
+insert space between items in the list of group names for readability. Notify user if an attempt to remove an in use
+group name is prevented. PEP8 and code cleanup to SG conventions. Removed fixed column widths, this means multiple groups
+have different column widths, but the original approach is preferred because fixed widths look bad with long show titles.
 
 
 ### 0.8.3 (2015-04-25 08:48:00 UTC)

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -350,6 +350,14 @@ inc_top.tmpl
 	-moz-osx-font-smoothing:grayscale
 }
 
+.dropdown [class^="sgicon-"], .dropdown [class*=" sgicon-"]{
+	margin-right:6px
+}
+
+#SubMenu [class^="sgicon-"], #SubMenu [class*=" sgicon-"]{
+	margin-right:3px
+}
+
 .sgicon-rss:before{
 	content:"\e622"
 }
@@ -1591,12 +1599,6 @@ td.col-subtitles{
 	text-align:center
 }
 
-th.col-simple,
-td.col-simple{
-	width: 150px;
-	text-align: center
-}
-
 th.col-status,
 td.col-status{
 	width:200px;
@@ -2084,7 +2086,7 @@ config*.tmpl
 
 .component-group-desc{
 	float:left;
-	width:250px;
+	width:240px;
 	padding-right:10px
 }
 
@@ -2164,7 +2166,7 @@ config*.tmpl
 .stepDiv span.component-title,
 #config span.component-title{
 	float:left;
-	width:172px;
+	width:182px;
 	margin-right:10px;
 	font-size:13px;
 	font-weight:bold
@@ -2180,7 +2182,7 @@ config*.tmpl
 	font-weight:normal;
 	display:block;
 	width:475px;
-	margin-left:182px
+	margin-left:192px
 }
 
 #config label.space-right{

--- a/gui/slick/interfaces/default/config_general.tmpl
+++ b/gui/slick/interfaces/default/config_general.tmpl
@@ -174,14 +174,14 @@
 								<span class="component-desc">
 									<input type="checkbox" name="auto_update" id="auto_update"#echo ('', $checked)[$sickbeard.AUTO_UPDATE]#>
 									<p>fetch and install software updates.
-									Updates are run on startup and in the background at the frequency set below*</p>
+									Updates are run on startup and in the background at the frequency set below<sup>1</sup></p>
 								</span>
 							</label>
 						</div>
 
 						<div class="field-pair">
 							<label>
-								<span class="component-title">Check the server every*</span>
+								<span class="component-title">Check the server every<sup>1</sup></span>
 								<span class="component-desc">
 									<input type="text" name="update_frequency" id="update_frequency" value="$sickbeard.UPDATE_FREQUENCY" class="form-control input-sm input75">
 									<p>hours for software updates (default:12)</p>
@@ -244,33 +244,28 @@
 
 						<div class="field-pair">
 							<label for="showlist_tagview">
-								<span class="component-title">Show list split view style:</span>
+								<span class="component-title">Group show list shows into:</span>
 								<span class="component-desc">
 									<select id="showlist_tagview" name="showlist_tagview" class="form-control input-sm">
-										<option value="standard"#echo ('', $selected)['standard' == $sickbeard.SHOWLIST_TAGVIEW]#>No Lists</option>
+										<option value="standard"#echo ('', $selected)['standard' == $sickbeard.SHOWLIST_TAGVIEW]#>One Show List</option>
 										<option value="anime"#echo ('', $selected)['anime' == $sickbeard.SHOWLIST_TAGVIEW]#>Show / Anime Lists</option>
 										<option value="custom"#echo ('', $selected)['custom' == $sickbeard.SHOWLIST_TAGVIEW]#>Custom Lists</option>
 									</select>
+									#set $hidden = ' class="hidden"'
+									<span id="showlist_tagview_standard"#echo ('', $hidden)['standard' not in $sickbeard.SHOWLIST_TAGVIEW]#>that contains all shows (default)</span>
+                                    <span id="showlist_tagview_anime"#echo ('', $hidden)['anime' not in $sickbeard.SHOWLIST_TAGVIEW]#>two groups, the show list and anime</span>
+                                    <span id="showlist_tagview_custom"#echo ('', $hidden)['custom' not in $sickbeard.SHOWLIST_TAGVIEW]#>multiple custom<sup>1</sup> named groups and a "Show List"</span>
 								</span>
 							</label>
 						</div>
 
-						<div class="field-pair #if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then 'hidden' else ''#">
+						<div id="showlist_tagview_custom_config" class="field-pair#if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then ' hidden' else ''#">
 							<label for="show_tags">
-								<span class="component-title">Show tags:</span>
+								<span class="component-title">Group names for show list<sup>1</sup></span>
 								<span class="component-desc">
 									<input type="text" name="show_tags" id="show_tags" value="$show_tags" class="form-control input-sm input300">
-                                    <p class="clear-left note">show tags are to be selected from these comma seperated words</p>
-								</span>
-							</label>
-						</div>
-
-						<div class="field-pair">
-							<label for="use_imdb_info">
-								<span class="component-title">Enable IMDb info</span>
-								<span class="component-desc">
-									<input type="checkbox" name="use_imdb_info" id="use_imdb_info"#echo ('', $checked)[$sickbeard.USE_IMDB_INFO]#>
-									<p>for ui links, display show; ratings, country flag, year, runtime, and genre tags</p>
+									<span>comma separated names</span>
+                                    <p class="clear-left note">group shows to the order of this custom list (add shows to groups with <a href="/manage/">mass edit</a>)</p>
 								</span>
 							</label>
 						</div>
@@ -281,6 +276,16 @@
 								<span class="component-desc">
 									<input type="checkbox" name="home_search_focus" id="home_search_focus"#echo ('', $checked)[$sickbeard.HOME_SEARCH_FOCUS]#>
 									<p>page refresh on "Show List" will start search box focused</p>
+								</span>
+							</label>
+						</div>
+
+						<div class="field-pair">
+							<label for="use_imdb_info">
+								<span class="component-title">Enable IMDb info</span>
+								<span class="component-desc">
+									<input type="checkbox" name="use_imdb_info" id="use_imdb_info"#echo ('', $checked)[$sickbeard.USE_IMDB_INFO]#>
+									<p>for ui links, display show; ratings, country flag, year, runtime, and genre tags</p>
 								</span>
 							</label>
 						</div>

--- a/gui/slick/interfaces/default/editShow.tmpl
+++ b/gui/slick/interfaces/default/editShow.tmpl
@@ -50,7 +50,6 @@
 		}
 		\$('#indexerLangSelectEdit').html(resultStr)
 
-        $('tag')
 	});
 });
 //-->
@@ -66,20 +65,6 @@
 <input type="hidden" name="show" value="$show.indexerid">
 
 	<div id="editShow" class="stepDiv linefix">
-
-		<div class="field-pair #if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then 'hidden' else ''#" style="margin-bottom:10px">
-			<label for="tag">
-				<span class="component-title">Tag</span>
-				<span class="component-desc">
-					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
-#for $tag in $sickbeard.SHOW_TAGS:
-						<option value="$tag" #if $tag == $show.tag then "selected=\"selected\"" else ""#>$tag</option>
-#end for
-					</select>
-					<span>used for show list page split view</span>
-				</span>
-			</label>
-		</div>
 
 		<div class="field-pair">
 			<label for="paused">
@@ -243,6 +228,20 @@
 				<span class="component-desc">
 					<input type="checkbox" name="anime" id="anime"#if $show.is_anime then $html_checked else ''#>
 					<p>enable if this show is anime and episode releases are named ... <em class="grey-text">Show.265</em> instead of <em class="grey-text">Show.S02E03</em></p>
+				</span>
+			</label>
+		</div>
+
+		<div class="field-pair#if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then ' hidden' else ''#" style="margin-bottom:10px">
+			<label for="tag">
+				<span class="component-title">Show is grouped in</span>
+				<span class="component-desc">
+					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
+#for $tag in $sickbeard.SHOW_TAGS:
+						<option value="$tag" #if $tag == $show.tag then 'selected="selected"' else ''#>$tag#echo ('', ' (default)')['Show List' == $tag]#</option>
+#end for
+					</select>
+					<span>and displays on the show list page under this section</span>
 				</span>
 			</label>
 		</div>

--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -2,16 +2,14 @@
 #import datetime
 #from sickbeard.common import *
 #from sickbeard import sbdatetime, network_timezones
-
-#set global $title="Home"
-#set global $header="Show List"
-
-#set global $sbPath = ".."
-
-#set global $topmenu="home"#
+##
+#set global $title = 'Home'
+#set global $header = 'Show List'
+#set global $sbPath = '..'
+#set global $topmenu = 'home'
+##
 #import os.path
-#include $os.path.join($sickbeard.PROG_DIR, "gui/slick/interfaces/default/inc_top.tmpl")
-
+#include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 
 <script type="text/javascript" charset="utf-8">
 <!--
@@ -23,11 +21,11 @@
 	},
 	format: function(s) {
 		if (s.indexOf('Loading...') == 0)
-			return s.replace('Loading...','000');
+			return s.replace('Loading...', '000');
 		else
-		#if not $sickbeard.SORT_ARTICLE:
+		#if not $sickbeard.SORT_ARTICLE
 			return (s || '').replace(/^(?:(?:A(?!\s+to)n?)|The)\s(\w)/i, '$1');
-		#else:
+		#else
 			return (s || '');
 		#end if
 	},
@@ -46,18 +44,19 @@
 });
 
 \$(document).ready(function(){
-
+#slurp
 #for $curShowlist in $showlists
-#set $curListID = $curShowlist[0]
-    #if $layout != 'poster'
-	\$("#$curListID:has(tbody tr)").tablesorter({
+    #set $curListID = $curShowlist[0]
+    #if 'poster' != $layout
+
+	\$('#$curListID:has(tbody tr)').tablesorter({
 		sortList: [[5,1],[1,0]],
 		textExtraction: {
-			0: function(node) { return \$(node).find("span").text().toLowerCase(); },
-			2: function(node) { return \$(node).find("span").text().toLowerCase(); },
-			3: function(node) { return \$(node).find("span").text().toLowerCase(); },
-			4: function(node) { return \$(node).find("span").text(); },
-			5: function(node) { return \$(node).find("img").attr("alt"); }
+			0: function(node) { return \$(node).find('span').text().toLowerCase(); },
+			2: function(node) { return \$(node).find('span').text().toLowerCase(); },
+			3: function(node) { return \$(node).find('span').text().toLowerCase(); },
+			4: function(node) { return \$(node).find('span').attr('data-progress'); },
+			5: function(node) { return \$(node).find('img').attr('alt'); }
 		},
 		widgets: ['saveSort', 'zebra', 'stickyHeaders', 'filter'],
 		headers: {
@@ -73,7 +72,7 @@
 		sortStable: true
 	});
 
-	\$.tablesorter.filter.bindSearch( "#$curListID", \$('.search') );
+	\$.tablesorter.filter.bindSearch( '#$curListID', \$('.search') );
 
     #else
 
@@ -92,30 +91,32 @@
 			getSortData: {
 				name: function( itemElem ) {
 					var name = \$( itemElem ).attr('data-name');
-					#if not $sickbeard.SORT_ARTICLE:
+        #if not $sickbeard.SORT_ARTICLE
 						return (name || '').replace(/^(?:(?:A(?!\s+to)n?)|The)\s(\w)/i, '$1');
-					#else:
+        #else
 						return (name || '');
-					#end if
+        #end if
 				},
-				network: '[data-network]',
 				date: function( itemElem ) {
 					var date = \$( itemElem ).attr('data-date');
 					return date.length && parseInt( date, 10 ) || Number.POSITIVE_INFINITY;
 				},
+				network: '[data-network]',
 				progress: function( itemElem ) {
-					var progress = \$( itemElem ).attr('data-progress');
+					var progress = \$( itemElem ).children('.item-data').attr('data-progress');
 					return progress.length && parseInt( progress, 10 ) || Number.NEGATIVE_INFINITY;
 				}
 			}
 		});
 	});
 
+
 	\$('#postersort').on( 'change', function() {
 		var sortValue = this.value;
 		\$('#$curListID').isotope({ sortBy: sortValue });
 		\$.get(this.options[this.selectedIndex].getAttribute('data-sort'));
 	});
+
 
 	\$('#postersortdirection').on( 'change', function() {
 		var sortDirection = this.value;
@@ -126,26 +127,29 @@
 	#end if
 #end for
 
-	\$("img#network").on('error', function(){
-		\$(this).parent().text(\$(this).attr('alt'));
-		\$(this).remove();
+#raw
+	$('img#network').on('error', function(){
+		$(this).parent().text($(this).attr('alt'));
+		$(this).remove();
 	});
+#end raw
 
-    #set $fuzzydate = 'airdate'
-    #if $sickbeard.FUZZY_DATING:
+#set $fuzzydate = 'airdate'
+#if $sickbeard.FUZZY_DATING
+
 	fuzzyMoment({
-		dtInline : #if $layout == 'poster' then "true" else "false"#,
+		dtInline : #if $layout == 'poster' then 'true' else 'false'#,
 		containerClass : '.${fuzzydate}',
 		dateHasTime : false,
 		dateFormat : '${sickbeard.DATE_PRESET}',
 		timeFormat : '${sickbeard.TIME_PRESET}',
-		trimZero : #if $sickbeard.TRIM_ZERO then "true" else "false"#
+		trimZero : #if $sickbeard.TRIM_ZERO then 'true' else 'false'#
 	});
-    #end if
-
-
+#end if
 #if $sickbeard.HOME_SEARCH_FOCUS
+
 	\$('#search_show_name').focus();
+
 #end if
 });
 
@@ -153,431 +157,420 @@
 </script>
 
 #if $varExists('header')
+
 	<h1 class="header" style="margin-bottom:0">$showlists[0][1]</h1>
 #else
+
 	<h1 class="title" style="margin-bottom:0">$title</h1>
 #end if
-
 #set $tab = 1
+#if 'poster' != $layout
 
-#if $layout != 'poster':
-<div id="HomeLayout" class="pull-right not-poster">
-	<div class="not-poster">
-		<input id="search_show_name" class="search form-control form-control-inline input-sm input200" type="search" data-column="1" placeholder="Search Show Name" tabindex="$tab#set $tab += 1#">
-		&nbsp;<button type="button" class="resetshows resetanime btn btn-inline" tabindex="$tab#set $tab += 1#">Reset Search</button>
-	</div>
-	<span class="pull-right not-poster"> Layout:
+	<div id="HomeLayout" class="pull-right not-poster">
+		<div class="not-poster">
+			<input id="search_show_name" class="search form-control form-control-inline input-sm input200" type="search" data-column="1" placeholder="Search Show Name" tabindex="$tab#set $tab += 1#">
+			&nbsp;<button type="button" class="resetshows resetanime btn btn-inline" tabindex="$tab#set $tab += 1#">Reset Search</button>
+		</div>
+		<span class="pull-right not-poster">Layout:
 #else
-<div id="HomeLayout" class="pull-right poster">
-	<span class="pull-right poster">Layout:
+
+	<div id="HomeLayout" class="pull-right poster">
+		<span class="pull-right poster">Layout:
 #end if
+#set $selected = ' selected="selected"'
+			<select name="layout" class="form-control form-control-inline input-sm" onchange="location = this.options[this.selectedIndex].value;" tabindex="$tab#set $tab += 1#">
+				<option value="$sbRoot/setHomeLayout/?layout=poster"#echo $selected if 'poster' == sickbeard.HOME_LAYOUT else ''#>Poster</option>
+				<option value="$sbRoot/setHomeLayout/?layout=small"#echo $selected if 'small' == sickbeard.HOME_LAYOUT else ''#>Small Poster</option>
+				<option value="$sbRoot/setHomeLayout/?layout=banner"#echo $selected if 'banner' == sickbeard.HOME_LAYOUT else ''#>Banner</option>
+				<option value="$sbRoot/setHomeLayout/?layout=simple"#echo $selected if 'simple' == sickbeard.HOME_LAYOUT else ''#>Simple</option>
+			</select>
+		</span>
 
-		<select name="layout" class="form-control form-control-inline input-sm" onchange="location = this.options[this.selectedIndex].value;" tabindex="$tab#set $tab += 1#">
-			<option value="$sbRoot/setHomeLayout/?layout=poster" #if $sickbeard.HOME_LAYOUT == "poster" then "selected=\"selected\"" else ""#>Poster</option>
-			<option value="$sbRoot/setHomeLayout/?layout=small" #if $sickbeard.HOME_LAYOUT == "small" then "selected=\"selected\"" else ""#>Small Poster</option>
-			<option value="$sbRoot/setHomeLayout/?layout=banner" #if $sickbeard.HOME_LAYOUT == "banner" then "selected=\"selected\"" else ""#>Banner</option>
-			<option value="$sbRoot/setHomeLayout/?layout=simple" #if $sickbeard.HOME_LAYOUT == "simple" then "selected=\"selected\"" else ""#>Simple</option>
-		</select>
-	</span>
+#if 'poster' == $layout
 
-    #if $layout == 'poster':
-	<span>Sort By:
-		<select id="postersort" class="form-control form-control-inline input-sm" tabindex="$tab#set $tab += 1#">
-			<option value="name" data-sort="$sbRoot/setPosterSortBy/?sort=name" #if $sickbeard.POSTER_SORTBY == "name" then "selected=\"selected\"" else ""#>Name</option>
-			<option value="date" data-sort="$sbRoot/setPosterSortBy/?sort=date" #if $sickbeard.POSTER_SORTBY == "date" then "selected=\"selected\"" else ""#>Next Episode</option>
-			<option value="network" data-sort="$sbRoot/setPosterSortBy/?sort=network" #if $sickbeard.POSTER_SORTBY == "network" then "selected=\"selected\"" else ""#>Network</option>
-			<option value="progress" data-sort="$sbRoot/setPosterSortBy/?sort=progress" #if $sickbeard.POSTER_SORTBY == "progress" then "selected=\"selected\"" else ""#>Progress</option>
-		</select>
-	</span>
-	<span style="margin:0 0 0 5px">Sort Order:
-		<select id="postersortdirection" class="form-control form-control-inline input-sm" tabindex="$tab#set $tab += 1#">
-			<option value="true" data-sort="$sbRoot/setPosterSortDir/?direction=1" #if $sickbeard.POSTER_SORTDIR == 1 then "selected=\"selected\"" else ""#>Asc</option>
-			<option value="false" data-sort="$sbRoot/setPosterSortDir/?direction=0" #if $sickbeard.POSTER_SORTDIR == 0 then "selected=\"selected\"" else ""#>Desc</option>
-		</select>
-	</span>
-	&nbsp;
+		<span>Sort By:
+			<select id="postersort" class="form-control form-control-inline input-sm" tabindex="$tab#set $tab += 1#">
+				<option value="name" data-sort="$sbRoot/setPosterSortBy/?sort=name"#echo $selected if 'name' == sickbeard.POSTER_SORTBY else ''#>Name</option>
+				<option value="date" data-sort="$sbRoot/setPosterSortBy/?sort=date"#echo $selected if 'date' == sickbeard.POSTER_SORTBY else ''#>Next Episode</option>
+				<option value="network" data-sort="$sbRoot/setPosterSortBy/?sort=network"#echo $selected if 'network' == sickbeard.POSTER_SORTBY else ''#>Network</option>
+				<option value="progress" data-sort="$sbRoot/setPosterSortBy/?sort=progress"#echo $selected if 'progress' == sickbeard.POSTER_SORTBY else ''#>Progress</option>
+			</select>
+		</span>
+		<span style="margin:0 0 0 5px">Sort Order:
+			<select id="postersortdirection" class="form-control form-control-inline input-sm" tabindex="$tab#set $tab += 1#">
+				<option value="true" data-sort="$sbRoot/setPosterSortDir/?direction=1"#echo $selected if 1 == sickbeard.POSTER_SORTDIR else ''#>Asc</option>
+				<option value="false" data-sort="$sbRoot/setPosterSortDir/?direction=0"#echo $selected if 0 == sickbeard.POSTER_SORTDIR else ''#>Desc</option>
+			</select>
+		</span>
+		&nbsp;
+#end if
+	</div><!-- /HomeLayout -->
 
-    #end if
-</div>
+#for $curShowlist in $showlists
+    #set $curListID = $curShowlist[0]
+    #set $curListName = $curShowlist[1]
+    #set $myShowList = $list($curShowlist[2])
+    #if $curShowlist != $showlists[0]
 
-
-#for $curShowlist in $showlists:
-#set $curListID = $curShowlist[0]
-#set $curListName = $curShowlist[1]
-#set $myShowList = $list($curShowlist[2])
-#if $curShowlist != $showlists[0]:
 	<h1 class="header">$curListName</h1>
-#end if
 
-#if $layout == 'poster':
-<div id="$curListID" class="clearfix container">
-<div class="posterview">
-#for $curLoadingShow in $sickbeard.showQueueScheduler.action.loadingShowList:
-
-    #if $curLoadingShow.show != None and $curLoadingShow.show in $sickbeard.showList:
-        #continue
     #end if
 
-    #if $curLoadingShow.show == None:
-		<div class="show" data-name="0" data-date="010101" data-network="0" data-progress="101">
-			<img alt="" title="$curLoadingShow.show_name" class="show-image" style="border-bottom: 1px solid #111;" src="$sbRoot/images/poster.png" />
-			<div class="show-details">
-				<div class="show-add">Loading... ($curLoadingShow.show_name)</div>
+    #if 'poster' == $layout
+
+	<div id="$curListID" class="clearfix container">
+		<div class="posterview">
+
+        #for $curLoadingShow in $sickbeard.showQueueScheduler.action.loadingShowList
+
+            #if $curLoadingShow.show != None and $curLoadingShow.show in $sickbeard.showList
+                #continue
+            #end if
+
+            #if None is $curLoadingShow.show
+
+			<div class="show" data-name="0" data-date="010101" data-network="0">
+				<span class="item-data" data-progress="101" style="display:none"></span>
+				<img alt="" title="$curLoadingShow.show_name" class="show-image" style="border-bottom:1px solid #111" src="$sbRoot/images/poster.png" />
+				<div class="show-details">
+					<div class="show-add">Loading... ($curLoadingShow.show_name)</div>
+				</div>
 			</div>
-		</div>
 
-    #end if
+            #end if
 
-#end for
+        #end for
 
-$myShowList.sort(lambda x, y: cmp(x.name, y.name))
-#for $curShow in $myShowList:
+        $myShowList.sort(lambda x, y: cmp(x.name, y.name))
+        #for $curShow in $myShowList
 
-    #set $cur_airs_next = ''
-    #set $cur_snatched = 0
-    #set $cur_downloaded = 0
-    #set $cur_total = 0
-    #set $download_stat_tip = ''
-    #set $display_status = $curShow.status
-    #if None is not $display_status
-        #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
-            #set $display_status = 'Continuing'
-        #else if re.search(r'(?i)(?:nded)', $curShow.status)
-            #set $display_status = 'Ended'
-        #end if
-    #end if
-
-    #if $curShow.indexerid in $show_stat:
-        #set $cur_airs_next = $show_stat[$curShow.indexerid]['ep_airs_next']
-
-        #set $cur_snatched = $show_stat[$curShow.indexerid]['ep_snatched']
-        #if not $cur_snatched:
+            #set $cur_airs_next = ''
             #set $cur_snatched = 0
-        #end if
-
-        #set $cur_downloaded = $show_stat[$curShow.indexerid]['ep_downloaded']
-        #if not $cur_downloaded:
             #set $cur_downloaded = 0
-        #end if
-
-        #set $cur_total = $show_stat[$curShow.indexerid]['ep_total']
-        #if not $cur_total:
             #set $cur_total = 0
-        #end if
-    #end if
+            #set $download_stat_tip = ''
+            #set $display_status = $curShow.status
+            #if None is not $display_status
+                #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
+                    #set $display_status = 'Continuing'
+                #else if re.search(r'(?i)(?:nded)', $curShow.status)
+                    #set $display_status = 'Ended'
+                #end if
+            #end if
 
-    #if $cur_total != 0:
-        #set $download_stat = str($cur_downloaded)
-        #set $download_stat_tip = "Downloaded: " + str($cur_downloaded)
-        #if $cur_snatched > 0:
-            #set $download_stat = download_stat
-            #set $download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str($cur_snatched)
-        #end if
-        #set $download_stat = download_stat + " / " + str($cur_total)
-        #set $download_stat_tip = download_stat_tip + "&#013;" + "Total: " + str($cur_total)
-    #else
-        #set $download_stat = '?'
-        #set $download_stat_tip = "no data"
-    #end if
+            #if $curShow.indexerid in $show_stat
+                #set $cur_airs_next = $show_stat[$curShow.indexerid]['ep_airs_next']
 
-    #set $nom = $cur_downloaded
-    #set $den = $cur_total
-    #if $den == 0:
-        #set $den = 1
-    #end if
+                #set $cur_snatched = $show_stat[$curShow.indexerid]['ep_snatched']
+                #if not $cur_snatched
+                    #set $cur_snatched = 0
+                #end if
 
-    #set $progressbar_percent = $nom * 100 / $den
+                #set $cur_downloaded = $show_stat[$curShow.indexerid]['ep_downloaded']
+                #if not $cur_downloaded
+                    #set $cur_downloaded = 0
+                #end if
 
-#set $data_date = '600000000000'
-#if $cur_airs_next:
-    #set $data_date = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next, $curShow.airs, $curShow.network)).strftime('%Y%m%d%H%M')
-#else if None is not $display_status
-    #if 'nded' not in $display_status and 1 == int($curShow.paused)
-        #set $data_date = '500000000500'
-    #else if 'ontinu' in $display_status
-        #set $data_date = '500000000000'
-    #else if 'nded' in $display_status
-        #set $data_date = '500000000100'
-    #end if
-#end if
-	<div class="show" id="show$curShow.indexerid" data-name="$curShow.name" data-date="$data_date" data-network="$curShow.network" data-progress="$progressbar_percent">
-		<div class="show-image">
-			<a href="$sbRoot/home/displayShow?show=$curShow.indexerid"><img alt="" class="show-image" src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster_thumb" /></a>
-		</div>
-		
-		<div id="progressbar$curShow.indexerid"></div>
-			<script type="text/javascript">
-			<!--
-				\$(function() {
-					\$("\#progressbar$curShow.indexerid").progressbar({
-					value: $progressbar_percent });
-					classvalue = $progressbar_percent
-					if (classvalue<20) {
-						classtoadd = "progress-20"
-					}
-					if (classvalue>=20 && classvalue<60) {
-						classtoadd = "progress-40"
-					}
-					if (classvalue>=40 && classvalue<80) {
-						classtoadd = "progress-60"
-					}
-					if (classvalue>=80) {
-						classtoadd = "progress-80"
-					}		
-					\$("\#progressbar$curShow.indexerid > .ui-progressbar-value").addClass(classtoadd);
-				});
-			//-->
-			</script>
-			
-		<div class="show-title">
-			$curShow.name
-		</div>
+                #set $cur_total = $show_stat[$curShow.indexerid]['ep_total']
+                #if not $cur_total
+                    #set $cur_total = 0
+                #end if
+            #end if
 
-		<div class="show-date">
-#if $cur_airs_next
-    #set $ldatetime = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next,$curShow.airs,$curShow.network))
-			<span class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdate($ldatetime)</span>
-#else
-    #set $output_html = '?'
-    #if None is not $display_status
-        #if 'nded' not in $display_status and 1 == int($curShow.paused)
-            #set $output_html = 'Paused'
-        #else if $display_status
-            #set $output_html = $display_status
-        #end if
-    #end if
-	$output_html
-#end if
-		</div>
+            #if $cur_total != 0
+                #set $download_stat = str($cur_downloaded)
+                #set $download_stat_tip = 'Downloaded: ' + str($cur_downloaded)
+                #if $cur_snatched > 0
+                    #set $download_stat = download_stat
+                    #set $download_stat_tip = download_stat_tip + '&#013;' + 'Snatched: ' + str($cur_snatched)
+                #end if
+                #set $download_stat = download_stat + ' / ' + str($cur_total)
+                #set $download_stat_tip = download_stat_tip + '&#013;' + 'Total: ' + str($cur_total)
+            #else
+                #set $download_stat = '?'
+                #set $download_stat_tip = 'no data'
+            #end if
 
-		<table width="100%" cellspacing="1" border="0" cellpadding="0">
-			<tr>
-				<td class="show-table">
-					<span class="show-dlstats" title="$download_stat_tip">$download_stat</span>
-				</td>
-				
-				<td class="show-table">
-#if 'simple' != $layout:
-    #set $img_text = ($curShow.network, 'No Network')[None is $curShow.network]
-					<img class="show-network-image" src="$sbRoot/images/network/$network_images[$curShow.indexerid]" alt="#echo '%s" title="%s' % ($img_text, $img_text)#" />
-#else:
-					$curShow.network
-#end if
-				</td>
-				
-				<td class="show-table">
-                    #if $curShow.quality in $qualityPresets:
-						<span class="show-quality">$qualityPresetStrings[$curShow.quality]</span>
-                    #else:
-						<span class="show-quality">Custom</span>
+            #set $nom = $cur_downloaded
+            #set $den = $cur_total
+            #if $den == 0
+                #set $den = 1
+            #end if
+
+            #set $progressbar_percent = $nom * 100 / $den
+
+            #set $data_date = '600000000000'
+            #if $cur_airs_next
+                #set $data_date = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next, $curShow.airs, $curShow.network)).strftime('%Y%m%d%H%M')
+            #else if None is not $display_status
+                #if 'nded' not in $display_status and 1 == int($curShow.paused)
+                    #set $data_date = '500000000500'
+                #else if 'ontinu' in $display_status
+                    #set $data_date = '500000000000'
+                #else if 'nded' in $display_status
+                    #set $data_date = '500000000100'
+                #end if
+            #end if
+
+			<div id="show$curShow.indexerid" class="show" data-name="$curShow.name" data-date="$data_date" data-network="$curShow.network">
+				<span class="item-data" data-progress="$progressbar_percent" style="display:none"></span>
+				<div class="show-image">
+					<a href="$sbRoot/home/displayShow?show=$curShow.indexerid"><img alt="" class="show-image" src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster_thumb" /></a>
+				</div>
+
+				<div id="progressbar$curShow.indexerid"></div>
+
+				<div class="show-title">
+					$curShow.name
+				</div>
+
+				<div class="show-date">
+            #if $cur_airs_next
+                #set $ldatetime = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next,$curShow.airs,$curShow.network))
+					<span class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdate($ldatetime)</span>
+            #else
+                #set $output_html = '?'
+                #if None is not $display_status
+                    #if 'nded' not in $display_status and 1 == int($curShow.paused)
+                        #set $output_html = 'Paused'
+                    #else if $display_status
+                        #set $output_html = $display_status
                     #end if
-				</td>
-			</tr>
-		</table>
-		
-	</div>
+                #end if
+					$output_html
+            #end if
+				</div><!-- /show-date -->
 
+				<table width="100%" cellspacing="1" border="0" cellpadding="0">
+					<tr>
+						<td class="show-table">
+							<span class="show-dlstats" title="$download_stat_tip">$download_stat</span>
+						</td>
 
-#end for
-</div> 
-</div> 
+						<td class="show-table">
+            #if 'simple' != $layout
+                #set $img_text = ($curShow.network, 'No Network')[None is $curShow.network]
+							<img class="show-network-image" src="$sbRoot/images/network/$network_images[$curShow.indexerid]" alt="#echo '%s" title="%s' % ($img_text, $img_text)#" />
+            #else
+							$curShow.network
+            #end if
+						</td>
 
-#else
+						<td class="show-table">
+            #if $curShow.quality in $qualityPresets
+							<span class="show-quality">$qualityPresetStrings[$curShow.quality]</span>
+            #else
+							<span class="show-quality">Custom</span>
+            #end if
+						</td>
+					</tr>
+				</table>
 
-<table id="$curListID" class="tablesorter" cellspacing="1" border="0" cellpadding="0">
+			</div><!-- /show$curShow.indexerid -->
 
-	<thead>
-        <tr>
-			<th class="col-airdate">Next Ep</th>
-			<th class="col-name">Show</th>
-			<th class="col-simple">Network</th>
-			<th class="col-simple">Quality</th>
-			<th class="col-simple">Downloads</th>
-			<th class="col-simple">Active</th>
-			<th class="col-simple">Status</th>
-        </tr>
-	</thead>
+        #end for
+		</div>
+	</div><!-- /$curListID -->
 
-	<tfoot>
-		<tr>
-			<th rowspan="1" colspan="1" align="center"><a href="$sbRoot/home/addShows/">Add Show</a></th>
-			<th rowspan="1" colspan="6"></th>
-		</tr>
-	</tfoot>
-
-	<tbody>
-
-#for $curLoadingShow in $sickbeard.showQueueScheduler.action.loadingShowList:
-
-    #if $curLoadingShow.show != None and $curLoadingShow.show in $sickbeard.showList:
-        #continue
-    #end if
-
-	<tr>
-		<td align="center">(loading)</td>
-		<td>
-        #if $curLoadingShow.show == None:
-		Loading... ($curLoadingShow.show_name)
-        #else:
-		<a href="displayShow?show=$curLoadingShow.show.indexerid">$curLoadingShow.show.name</a>
-        #end if
-		</td>
-		<td></td>
-		<td></td>
-		<td></td>
-		<td></td>
-		<td></td>
-	</tr>
-#end for
-
-$myShowList.sort(lambda x, y: cmp(x.name, y.name))
-#for $curShow in $myShowList:
-
-    #set $cur_airs_next = ''
-    #set $cur_snatched = 0
-    #set $cur_downloaded = 0
-    #set $cur_total = 0
-    #set $download_stat_tip = ''
-
-    #if $curShow.indexerid in $show_stat:
-        #set $cur_airs_next = $show_stat[$curShow.indexerid]['ep_airs_next']
-
-        #set $cur_snatched = $show_stat[$curShow.indexerid]['ep_snatched']
-        #if not $cur_snatched:
-            #set $cur_snatched = 0
-        #end if
-
-        #set $cur_downloaded = $show_stat[$curShow.indexerid]['ep_downloaded']
-        #if not $cur_downloaded:
-            #set $cur_downloaded = 0
-        #end if
-
-        #set $cur_total = $show_stat[$curShow.indexerid]['ep_total']
-        #if not $cur_total:
-            #set $cur_total = 0
-        #end if
-    #end if
-
-    #if $cur_total != 0:
-        #set $download_stat = str($cur_downloaded)
-        #set $download_stat_tip = "Downloaded: " + str($cur_downloaded)
-        #if $cur_snatched > 0:
-            #set $download_stat = download_stat + "+" + str($cur_snatched)
-            #set $download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str($cur_snatched)
-        #end if
-        #set $download_stat = download_stat + " / " + str($cur_total)
-        #set $download_stat_tip = download_stat_tip + "&#013;" + "Total: " + str($cur_total)
+########################
+## end of poster layout
+########################
     #else
-        #set $download_stat = '?'
-        #set $download_stat_tip = "no data"
+
+	<table id="$curListID" class="tablesorter" cellspacing="1" border="0" cellpadding="0">
+
+		<thead>
+			<tr>
+				<th>Next Ep</th>
+				<th>Show</th>
+				<th>Network</th>
+				<th>Quality</th>
+				<th>Downloads</th>
+				<th>Active</th>
+				<th>Status</th>
+			</tr>
+		</thead>
+
+		<tfoot>
+			<tr>
+				<th rowspan="1" colspan="1" align="center"><a href="$sbRoot/home/addShows/">Add Show</a></th>
+				<th rowspan="1" colspan="6"></th>
+			</tr>
+		</tfoot>
+
+		<tbody>
+        #for $curLoadingShow in $sickbeard.showQueueScheduler.action.loadingShowList
+            #if $curLoadingShow.show != None and $curLoadingShow.show in $sickbeard.showList
+                #continue
+            #end if
+
+			<tr>
+				<td align="center">(loading)</td>
+				<td>
+            #if None is $curLoadingShow.show
+					Loading... ($curLoadingShow.show_name)
+            #else
+					<a href="displayShow?show=$curLoadingShow.show.indexerid">$curLoadingShow.show.name</a>
+            #end if
+				</td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+				<td></td>
+			</tr>
+        #end for
+
+    $myShowList.sort(lambda x, y: cmp(x.name, y.name))
+        #for $curShow in $myShowList
+            #slurp
+            #set $cur_airs_next = ''
+            #set $cur_snatched = 0
+            #set $cur_downloaded = 0
+            #set $cur_total = 0
+            #set $download_stat_tip = ''
+            #slurp
+            #if $curShow.indexerid in $show_stat
+                #set $cur_airs_next = $show_stat[$curShow.indexerid]['ep_airs_next']
+                #slurp
+                #set $cur_snatched = $show_stat[$curShow.indexerid]['ep_snatched']
+                #if not $cur_snatched
+                    #set $cur_snatched = 0
+                #end if
+                #slurp
+                #set $cur_downloaded = $show_stat[$curShow.indexerid]['ep_downloaded']
+                #if not $cur_downloaded
+                    #set $cur_downloaded = 0
+                #end if
+                #slurp
+                #set $cur_total = $show_stat[$curShow.indexerid]['ep_total']
+                #if not $cur_total
+                    #set $cur_total = 0
+                #end if
+            #end if
+            #slurp
+            #if $cur_total != 0
+                #set $download_stat = str($cur_downloaded)
+                #set $download_stat_tip = 'Downloaded: ' + str($cur_downloaded)
+                #if $cur_snatched > 0
+                    #set $download_stat = download_stat + '+' + str($cur_snatched)
+                    #set $download_stat_tip = download_stat_tip + '&#013;' + 'Snatched: ' + str($cur_snatched)
+                #end if
+                #set $download_stat = download_stat + ' / ' + str($cur_total)
+                #set $download_stat_tip = download_stat_tip + '&#013;' + 'Total: ' + str($cur_total)
+            #else
+                #set $download_stat = '?'
+                #set $download_stat_tip = 'no data'
+            #end if
+            #slurp
+            #set $nom = $cur_downloaded
+            #set $den = $cur_total
+            #if $den == 0
+                #set $den = 1
+            #end if
+            #slurp
+            #set $progressbar_percent = $nom * 100 / $den
+
+			<tr>
+            #if $cur_airs_next
+                #set $ldatetime = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next,$curShow.airs,$curShow.network))
+
+				<td align="center" class="nowrap"><div class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdate($ldatetime)</div><span class="sort_data">$ldatetime.strftime('%Y%m%d%H%M')</span></td>
+            #else
+
+				<td align="center" class="nowrap"></td>
+            #end if
+            #if 'small' == $layout
+
+				<td class="tvShow">
+					<div class="imgsmallposter $layout">
+						<a href="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster" rel="dialog" title="$curShow.name">
+							<img src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster_thumb" class="$layout" alt="$curShow.indexerid"/>
+						</a>
+						<a href="$sbRoot/home/displayShow?show=$curShow.indexerid" style="vertical-align:middle">$curShow.name</a>
+					</div>
+				</td>
+            #else if 'banner' == $layout
+
+				<td>
+					<span style="display:none">$curShow.name</span>
+					<div class="imgbanner $layout">
+						<a href="$sbRoot/home/displayShow?show=$curShow.indexerid">
+						<img src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=banner" class="$layout" alt="$curShow.indexerid" title="$curShow.name"/>
+					</div>
+				</td>
+            #else if 'simple' == $layout
+
+				<td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.indexerid">$curShow.name</a></td>
+            #end if
+
+            #if 'simple' != $layout
+                #set $img_text = ($curShow.network, 'No Network')[None is $curShow.network]
+
+				<td align="center">
+					<span style="display:none">$curShow.network</span>
+					<img width="54" height="27" src="$sbRoot/images/network/$network_images[$curShow.indexerid]" alt="#echo '%s" title="%s' % ($img_text, $img_text)#" />
+				</td>
+            #else
+
+				<td>
+					<span>$curShow.network</span>
+				</td>
+            #end if
+
+            #if $curShow.quality in $qualityPresets
+
+				<td align="center"><span class="quality $qualityPresetStrings[$curShow.quality]">$qualityPresetStrings[$curShow.quality]</span></td>
+            #else
+
+				<td align="center"><span class="quality Custom">Custom</span></td>
+            #end if
+
+				<td align="center">
+					<span class="item-data" data-progress="$progressbar_percent" style="display:none"></span>
+					<div id="progressbar$curShow.indexerid" style="position:relative">
+						<div class="progressbarText" title="$download_stat_tip">$download_stat</div>
+					</div>
+				</td>
+
+				<td align="center">
+					<img src="$sbRoot/images/#if int($curShow.paused) == 0 and $curShow.status != 'Ended' then 'yes16.png" alt="Y"' else 'no16.png" alt="N"'# width="16" height="16" />
+				</td>
+
+				<td align="center">
+            #set $display_status = $curShow.status
+            #if None is not $display_status
+                #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
+                    #set $display_status = 'Continuing'
+                #else if re.search(r'(?i)(?:nded)', $curShow.status)
+                    #set $display_status = 'Ended'
+                #end if
+            #end if
+					$display_status
+				</td>
+
+			</tr>
+        #end for
+		</tbody>
+	</table>
+
     #end if
-
-    #set $nom = $cur_downloaded
-    #set $den = $cur_total
-    #if $den == 0:
-        #set $den = 1
-    #end if
-
-    #set $progressbar_percent = $nom * 100 / $den
-
-	<tr>
-	
-    #if $cur_airs_next
-    #set $ldatetime = $sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($cur_airs_next,$curShow.airs,$curShow.network))
-		<td align="center" class="nowrap"><div class="${fuzzydate}">$sbdatetime.sbdatetime.sbfdate($ldatetime)</div><span class="sort_data">$ldatetime.strftime('%Y%m%d%H%M')</span></td>
-    #else:
-		<td align="center" class="nowrap"></td>
-    #end if
-
-    #if $layout == 'small':
-		<td class="tvShow">
-			<div class="imgsmallposter $layout">
-				<a href="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster" rel="dialog" title="$curShow.name">
-					<img src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=poster_thumb" class="$layout" alt="$curShow.indexerid"/>
-				</a>
-				<a href="$sbRoot/home/displayShow?show=$curShow.indexerid" style="vertical-align: middle;">$curShow.name</a>
-			</div>
-		</td>
-    #else if $layout == 'banner':
-		<td>
-			<span style="display: none;">$curShow.name</span>
-			<div class="imgbanner $layout">
-				<a href="$sbRoot/home/displayShow?show=$curShow.indexerid">
-				<img src="$sbRoot/showPoster/?show=$curShow.indexerid&amp;which=banner" class="$layout" alt="$curShow.indexerid" title="$curShow.name"/>
-			</div>
-		</td>
-    #else if $layout == 'simple':
-		<td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.indexerid">$curShow.name</a></td>
-    #end if
-
-    #if 'simple' != $layout:
-        #set $img_text = ($curShow.network, 'No Network')[None is $curShow.network]
-		<td align="center">
-			<span style="display: none;">$curShow.network</span>
-			<img width="54" height="27" src="$sbRoot/images/network/$network_images[$curShow.indexerid]" alt="#echo '%s" title="%s' % ($img_text, $img_text)#" />
-		</td>
-    #else:
-		<td>
-			<span>$curShow.network</span>
-		</td>
-    #end if
-
-    #if $curShow.quality in $qualityPresets:
-		<td align="center"><span class="quality $qualityPresetStrings[$curShow.quality]">$qualityPresetStrings[$curShow.quality]</span></td>
-    #else:
-		<td align="center"><span class="quality Custom">Custom</span></td>
-    #end if
-
-		<td align="center"><span style="display: none;">$progressbar_percent</span><div id="progressbar$curShow.indexerid" style="position:relative;"></div>
-			<script type="text/javascript">
-			<!--
-				\$(function() {
-					\$("\#progressbar$curShow.indexerid").progressbar({
-					value: $progressbar_percent });
-					\$("\#progressbar$curShow.indexerid").append( "<div class='progressbarText' title='$download_stat_tip'>$download_stat</div>" )
-					classvalue = $progressbar_percent
-					if (classvalue<20) {
-						classtoadd = "progress-20"
-					}
-					if (classvalue>=20 && classvalue<60) {
-						classtoadd = "progress-40"
-					}
-					if (classvalue>=40 && classvalue<80) {
-						classtoadd = "progress-60"
-					}
-					if (classvalue>=80) {
-						classtoadd = "progress-80"
-					}
-					\$("\#progressbar$curShow.indexerid > .ui-progressbar-value").addClass(classtoadd);
-				});
-			//-->
-			</script>
-		</td>
-
-		<td align="center">
-			<img src="$sbRoot/images/#if int($curShow.paused) == 0 and $curShow.status != "Ended" then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" />
-		</td>
-		
-		<td align="center">
-
-#set $display_status = $curShow.status
-#if None is not $display_status
-    #if re.search(r'(?i)(?:new|returning)\s*series', $curShow.status)
-        #set $display_status = 'Continuing'
-    #else if re.search(r'(?i)(?:nded)', $curShow.status)
-        #set $display_status = 'Ended'
-    #end if
-#end if
-			$display_status
-		</td>
-		
-	</tr>
-
 #end for
-</tbody>
-</table>
 
-#end if
-#end for
-
-#include $os.path.join($sickbeard.PROG_DIR,"gui/slick/interfaces/default/inc_bottom.tmpl")
+<script type="text/javascript">
+<!--
+#raw
+$(document).ready(function(){
+	$('div[id^="progressbar"]').each(function(k, v){
+		var progress = parseInt($(this).siblings('span[class="item-data"]').attr('data-progress'), 10) , elId = '#' + $(this).attr('id'), v = 80;
+		$(elId).progressbar({value:progress});
+		if (progress < 80) {
+			v = progress >= 40 ? 60 : (progress >= 20 ? 40 : 20);
+		}
+		$(elId + ' > .ui-progressbar-value').addClass('progress-' + v);
+	});
+});
+#end raw
+//-->
+</script>
+#include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_bottom.tmpl')

--- a/gui/slick/interfaces/default/inc_addShowOptions.tmpl
+++ b/gui/slick/interfaces/default/inc_addShowOptions.tmpl
@@ -27,21 +27,6 @@
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_qualityChooser.tmpl')
 		</div>
 
-		<div class="field-pair #if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then 'hidden' else ''#" style="margin-bottom:10px">
-			<label for="tag">
-				<span class="component-title">Tag</span>
-				<span class="component-desc">
-					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
-#for $tag in $sickbeard.SHOW_TAGS:
-						<option value="$tag" #if $tag == $sickbeard.DEFAULT_SHOW_TAG then "selected=\"selected\"" else ""#>$tag</option>
-#end for
-					</select>
-					<span>used for show list page split view</span>
-				</span>
-			</label>
-		</div>
-
-
 #try:
     #if True == $enable_default_wanted:
 		<div class="field-pair alt">
@@ -64,6 +49,20 @@
 #except (NameError, NotFound):
     #pass
 #end try
+
+		<div class="field-pair #if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then 'hidden' else ''#" style="margin-top:10px">
+			<label for="tag">
+				<span class="component-title">Place show in group</span>
+				<span class="component-desc">
+					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
+#for $tag in $sickbeard.SHOW_TAGS:
+						<option value="$tag" #if $tag == $sickbeard.DEFAULT_SHOW_TAG then 'selected="selected"' else ''#>$tag</option>
+#end for
+					</select>
+					<span>and display on the show list page under this section</span>
+				</span>
+			</label>
+		</div>
 
 		<div class="field-pair alt">
 			<label for="flatten_folders">

--- a/gui/slick/interfaces/default/inc_top.tmpl
+++ b/gui/slick/interfaces/default/inc_top.tmpl
@@ -1,130 +1,124 @@
 #import sickbeard
 #import urllib
-
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<title>SickGear - BRANCH:[$sickbeard.BRANCH] - $title</title>
+	<title>SickGear - BRANCH:[$sickbeard.BRANCH] - $title</title>
 	
-		<!--[if lt IE 9]>
-			<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-			<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-		<![endif]-->
+	<!--[if lt IE 9]>
+	<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+	<![endif]-->
 
-		<link rel="shortcut icon" href="$sbRoot/images/ico/favicon.ico">
-		<link rel="apple-touch-icon" sizes="180x180" href="$sbRoot/images/ico/apple-touch-icon-180x180.png">
-		<link rel="apple-touch-icon" sizes="152x152" href="$sbRoot/images/ico/apple-touch-icon-152x152.png">
-		<link rel="apple-touch-icon" sizes="144x144" href="$sbRoot/images/ico/apple-touch-icon-144x144.png">
-		<link rel="apple-touch-icon" sizes="120x120" href="$sbRoot/images/ico/apple-touch-icon-120x120.png">
-		<link rel="apple-touch-icon" sizes="114x114" href="$sbRoot/images/ico/apple-touch-icon-114x114.png">
-		<link rel="apple-touch-icon" sizes="76x76" href="$sbRoot/images/ico/apple-touch-icon-76x76.png">
-		<link rel="apple-touch-icon" sizes="72x72" href="$sbRoot/images/ico/apple-touch-icon-72x72.png">
-		<link rel="apple-touch-icon" sizes="60x60" href="$sbRoot/images/ico/apple-touch-icon-60x60.png">
-		<link rel="apple-touch-icon" sizes="57x57" href="$sbRoot/images/ico/apple-touch-icon-57x57.png">		
-		<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-192x192.png" sizes="192x192">
-		<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-160x160.png" sizes="160x160">
-		<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-96x96.png" sizes="96x96">
-		<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-32x32.png" sizes="32x32">
-		<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-16x16.png" sizes="16x16">
-		<meta name="msapplication-TileColor" content="#2b5797">
-		<meta name="msapplication-TileImage" content="$sbRoot/images/ico/mstile-144x144.png">
-		<meta name="msapplication-config" content="$sbRoot/css/browserconfig.xml">
+	<link rel="shortcut icon" href="$sbRoot/images/ico/favicon.ico">
+	<link rel="apple-touch-icon" sizes="180x180" href="$sbRoot/images/ico/apple-touch-icon-180x180.png">
+	<link rel="apple-touch-icon" sizes="152x152" href="$sbRoot/images/ico/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon" sizes="144x144" href="$sbRoot/images/ico/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon" sizes="120x120" href="$sbRoot/images/ico/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon" sizes="114x114" href="$sbRoot/images/ico/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon" sizes="76x76" href="$sbRoot/images/ico/apple-touch-icon-76x76.png">
+	<link rel="apple-touch-icon" sizes="72x72" href="$sbRoot/images/ico/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon" sizes="60x60" href="$sbRoot/images/ico/apple-touch-icon-60x60.png">
+	<link rel="apple-touch-icon" sizes="57x57" href="$sbRoot/images/ico/apple-touch-icon-57x57.png">		
+	<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-192x192.png" sizes="192x192">
+	<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-160x160.png" sizes="160x160">
+	<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-96x96.png" sizes="96x96">
+	<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-32x32.png" sizes="32x32">
+	<link rel="icon" type="image/png" href="$sbRoot/images/ico/favicon-16x16.png" sizes="16x16">
+	<meta name="msapplication-TileColor" content="#2b5797">
+	<meta name="msapplication-TileImage" content="$sbRoot/images/ico/mstile-144x144.png">
+	<meta name="msapplication-config" content="$sbRoot/css/browserconfig.xml">
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/bootstrap.css?$sbPID"/>
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/browser.css?$sbPID" />
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery-ui-1.10.4.custom.css?$sbPID" />
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery.qtip-2.2.1.min.css?$sbPID"/>
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/pnotify.custom.min.css?$sbPID" />
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/style.css?$sbPID"/>
+	<link rel="stylesheet" type="text/css" href="$sbRoot/css/${sickbeard.THEME_NAME}.css?$sbPID" />
 
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/bootstrap.css?$sbPID"/>
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/browser.css?$sbPID" />
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery-ui-1.10.4.custom.css?$sbPID" />
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery.qtip-2.2.1.min.css?$sbPID"/>
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/pnotify.custom.min.css?$sbPID" />
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/style.css?$sbPID"/>
-		<link rel="stylesheet" type="text/css" href="$sbRoot/css/${sickbeard.THEME_NAME}.css?$sbPID" />
-
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery-1.8.3.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/bootstrap.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/bootstrap-hover-dropdown.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery-ui-1.10.4.custom.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.cookie.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.cookiejar.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.json-2.2.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.selectboxes.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter-2.17.7.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter.widgets-2.17.7.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.qtip-2.2.1.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/pnotify.custom.min.js"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.form-3.35.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.ui.touch-punch-0.2.2.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/isotope.pkgd.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/imagesloaded.pkgd.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.confirm.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/script.js?$sbPID"></script>
-#if $sickbeard.FUZZY_DATING:
-		<script type="text/javascript" src="$sbRoot/js/moment/moment.min.js?$sbPID"></script>
-		<script type="text/javascript" src="$sbRoot/js/fuzzyMoment.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery-1.8.3.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/bootstrap.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/bootstrap-hover-dropdown.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery-ui-1.10.4.custom.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.cookie.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.cookiejar.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.json-2.2.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.selectboxes.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter-2.17.7.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter.widgets-2.17.7.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.qtip-2.2.1.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/pnotify.custom.min.js"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.form-3.35.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.ui.touch-punch-0.2.2.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/isotope.pkgd.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/imagesloaded.pkgd.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.confirm.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/script.js?$sbPID"></script>
+#if $sickbeard.FUZZY_DATING
+	<script type="text/javascript" src="$sbRoot/js/moment/moment.min.js?$sbPID"></script>
+	<script type="text/javascript" src="$sbRoot/js/fuzzyMoment.js?$sbPID"></script>
 #end if
-		<script type="text/javascript" charset="utf-8">
-		<!--
-			sbRoot = '$sbRoot'; // needed for browser.js & ajaxNotifications.js
-			//HTML for scrolltopcontrol, which is auto wrapped in DIV w/ ID="topcontrol"
+	<script type="text/javascript" charset="utf-8">
+	<!--
+		var sbRoot = '$sbRoot', anonURL = '$sickbeard.ANON_REDIRECT', themeSpinner = '#echo ('', '-dark')['dark' == $sickbeard.THEME_NAME]#'
 			top_image_html = '<img src="$sbRoot/images/top.gif" width="31" height="11" alt="Jump to top" />';
-			themeSpinner = <%= '\'\'' if 'dark' != sickbeard.THEME_NAME else '\'-dark\'' %>;
-			anonURL = '<%= sickbeard.ANON_REDIRECT %>'
-		//-->
-		</script>
-		<script type="text/javascript" src="$sbRoot/js/lib/jquery.scrolltopcontrol-1.1.js"></script>
-		<script type="text/javascript" src="$sbRoot/js/browser.js"></script>
-		<script type="text/javascript" src="$sbRoot/js/ajaxNotifications.js"></script>
-		<script type="text/javascript">
-		<!--
-			function initActions() {
-				\$("#SubMenu a[href*='/home/restart/']").addClass('btn restart').html('<i class="sgicon-restart"></i> Restart');
-				\$("#SubMenu a[href*='/home/shutdown/']").addClass('btn shutdown').html('<i class="sgicon-shutdown"></i> Shutdown');
-				\$("#SubMenu a[href*='/home/logout/']").addClass('btn').html('<i class="sgicon-logout"></i> Logout');
-				\$("#SubMenu a:contains('Edit')").addClass('btn').html('<i class="sgicon-edit"></i> Edit');
-				\$("#SubMenu a:contains('Remove')").addClass('btn remove').html('<i class="sgicon-delete"></i> Remove');
-				\$("#SubMenu a:contains('Clear History')").addClass('btn clearhistory').html('<i class="sgicon-delete"></i> Clear History');
-				\$("#SubMenu a:contains('Trim History')").addClass('btn trimhistory').html('<i class="sgicon-trim"></i> Trim History');
-				\$("#SubMenu a[href$='/errorlogs/clearerrors/']").addClass('btn').html('<i class="sgicon-delete"></i> Clear Errors');
-				\$("#SubMenu a:contains('Re-scan')").addClass('btn').html('<i class="sgicon-refresh"></i> Re-scan');
-				\$("#SubMenu a:contains('Backlog Overview')").addClass('btn').html('<i class="sgicon-backlog"></i> Backlog Overview');
-				\$("#SubMenu a[href$='/home/updatePLEX/']").addClass('btn').html('<i class="sgicon-plex"></i>Update PLEX');
-				\$("#SubMenu a:contains('Force')").addClass('btn').html('<i class="sgicon-fullupdate"></i> Force Full Update');
-				\$("#SubMenu a:contains('Rename')").addClass('btn').html('<i class="sgicon-rename"></i> Preview Rename');
-				\$("#SubMenu a[href$='/config/subtitles/']").addClass('btn').html('<i class="sgicon-subtitles"></i> Search Subtitles');
-				\$("#SubMenu a[href*='/home/subtitleShow']").addClass('btn').html('<i class="sgicon-subtitles"></i> Download Subtitles');
-				\$("#SubMenu a:contains('Anime')").addClass('btn').html('<i class="sgicon-anime"></i> Anime');
-				\$("#SubMenu a:contains('Settings')").addClass('btn').html('<i class="sgicon-search"></i> Search Settings');
-				\$("#SubMenu a:contains('Provider')").addClass('btn').html('<i class="sgicon-search"></i> Search Providers');
-				\$("#SubMenu a:contains('General')").addClass('btn').html('<i class="sgicon-config"></i> General');
-				\$("#SubMenu a:contains('Episode Status')").addClass('btn').html('<i class="sgicon-episodestatus"></i> Episode Status Management');
-				\$("#SubMenu a:contains('Missed Subtitle')").addClass('btn').html('<i class="sgicon-subtitles"></i> Missed Subtitles');
-				\$("#SubMenu a[href$='/home/addShows/']").addClass('btn').html('<i class="sgicon-addshow"></i> Add Show');
-				\$("#SubMenu a:contains('Processing')").addClass('btn').html('<i class="sgicon-postprocess"></i> Post-Processing');
-				\$("#SubMenu a:contains('Manage Searches')").addClass('btn').html('<i class="sgicon-search"></i> Manage Searches');
-				\$("#SubMenu a:contains('Manage Torrents')").addClass('btn').html('<i class="sgicon-bittorrent"></i> Manage Torrents');
-				\$("#SubMenu a[href$='/manage/failedDownloads/']").addClass('btn').html('<i class="sgicon-failed"></i> Failed Downloads');
-				\$("#SubMenu a:contains('Notification')").addClass('btn').html('<i class="sgicon-notification"></i> Notifications');
-				\$("#SubMenu a:contains('Update show in XBMC')").addClass('btn').html('<i class="sgicon-xbmc"></i> Update show in XBMC');
-				\$("#SubMenu a[href$='/home/updateXBMC/']").addClass('btn').html('<i class="sgicon-xbmc"></i> Update XBMC');
-				\$("#SubMenu a:contains('Update show in Kodi')").addClass('btn').html('<i class="sgicon-kodi"></i> Update show in Kodi');
-				\$("#SubMenu a[href$='/home/updateKODI/']").addClass('btn').html('<i class="sgicon-kodi"></i> Update Kodi');
-			}
-		
-			\$(document).ready(function() {
-				
-				initActions();
-				
-				\$("#NAV$topmenu").addClass("active");
-				
-				\$('.dropdown-toggle').dropdownHover();
+	//-->
+	</script>
+	<script type="text/javascript" src="$sbRoot/js/lib/jquery.scrolltopcontrol-1.1.js"></script>
+	<script type="text/javascript" src="$sbRoot/js/browser.js"></script>
+	<script type="text/javascript" src="$sbRoot/js/ajaxNotifications.js"></script>
+	<script type="text/javascript">
+	<!--
+#raw
+		function initActions() {
+			$('#SubMenu a[href*="/home/restart/"]').addClass('btn restart').html('<i class="sgicon-restart"></i>Restart');
+			$('#SubMenu a[href*="/home/shutdown/"]').addClass('btn shutdown').html('<i class="sgicon-shutdown"></i>Shutdown');
+			$('#SubMenu a[href*="/home/logout/"]').addClass('btn').html('<i class="sgicon-logout"></i>Logout');
+			$('#SubMenu a:contains("Edit")').addClass('btn').html('<i class="sgicon-edit"></i>Edit');
+			$('#SubMenu a:contains("Remove")').addClass('btn remove').html('<i class="sgicon-delete"></i>Remove');
+			$('#SubMenu a:contains("Clear History")').addClass('btn clearhistory').html('<i class="sgicon-delete"></i>Clear History');
+			$('#SubMenu a:contains("Trim History")').addClass('btn trimhistory').html('<i class="sgicon-trim"></i>Trim History');
+			$('#SubMenu a[href$="/errorlogs/clearerrors/"]').addClass('btn').html('<i class="sgicon-delete"></i>Clear Errors');
+			$('#SubMenu a:contains("Re-scan")').addClass('btn').html('<i class="sgicon-refresh"></i>Re-scan');
+			$('#SubMenu a:contains("Backlog Overview")').addClass('btn').html('<i class="sgicon-backlog"></i>Backlog Overview');
+			$('#SubMenu a[href$="/home/updatePLEX/"]').addClass('btn').html('<i class="sgicon-plex"></i>Update PLEX');
+			$('#SubMenu a:contains("Force")').addClass('btn').html('<i class="sgicon-fullupdate"></i>Force Full Update');
+			$('#SubMenu a:contains("Rename")').addClass('btn').html('<i class="sgicon-rename"></i>Preview Rename');
+			$('#SubMenu a[href$="/config/subtitles/"]').addClass('btn').html('<i class="sgicon-subtitles"></i>Search Subtitles');
+			$('#SubMenu a[href*="/home/subtitleShow"]').addClass('btn').html('<i class="sgicon-subtitles"></i>Download Subtitles');
+			$('#SubMenu a:contains("Anime")').addClass('btn').html('<i class="sgicon-anime"></i>Anime');
+			$('#SubMenu a:contains("Settings")').addClass('btn').html('<i class="sgicon-search"></i>Search Settings');
+			$('#SubMenu a:contains("Provider")').addClass('btn').html('<i class="sgicon-search"></i>Search Providers');
+			$('#SubMenu a:contains("General")').addClass('btn').html('<i class="sgicon-config"></i>General');
+			$('#SubMenu a:contains("Episode Status")').addClass('btn').html('<i class="sgicon-episodestatus"></i>Episode Status Management');
+			$('#SubMenu a:contains("Missed Subtitle")').addClass('btn').html('<i class="sgicon-subtitles"></i>Missed Subtitles');
+			$('#SubMenu a[href$="/home/addShows/"]').addClass('btn').html('<i class="sgicon-addshow"></i>Add Show');
+			$('#SubMenu a:contains("Processing")').addClass('btn').html('<i class="sgicon-postprocess"></i>Post-Processing');
+			$('#SubMenu a:contains("Manage Searches")').addClass('btn').html('<i class="sgicon-search"></i>Manage Searches');
+			$('#SubMenu a:contains("Manage Torrents")').addClass('btn').html('<i class="sgicon-bittorrent"></i>Manage Torrents');
+			$('#SubMenu a[href$="/manage/failedDownloads/"]').addClass('btn').html('<i class="sgicon-failed"></i>Failed Downloads');
+			$('#SubMenu a:contains("Notification")').addClass('btn').html('<i class="sgicon-notification"></i>Notifications');
+			$('#SubMenu a:contains("Update show in XBMC")').addClass('btn').html('<i class="sgicon-xbmc"></i>Update show in XBMC');
+			$('#SubMenu a[href$="/home/updateXBMC/"]').addClass('btn').html('<i class="sgicon-xbmc"></i>Update XBMC');
+			$('#SubMenu a:contains("Update show in Kodi")').addClass('btn').html('<i class="sgicon-kodi"></i>Update show in Kodi');
+			$('#SubMenu a[href$="/home/updateKODI/"]').addClass('btn').html('<i class="sgicon-kodi"></i>Update Kodi');
+		}
+#end raw	
+		\$(document).ready(function() {
+			
+			initActions();
+			\$("#NAV$topmenu").addClass("active");
+			\$('.dropdown-toggle').dropdownHover();
 
-			});
-		//-->
-		</script>
-		<script type="text/javascript" src="$sbRoot/js/confirmations.js?$sbPID"></script>
-	</head>
+		});
+	//-->
+	</script>
+	<script type="text/javascript" src="$sbRoot/js/confirmations.js?$sbPID"></script>
+</head>
 #set $tab = 4
 #set $body_attr = ''
 #try
@@ -132,148 +126,153 @@
 #except
     #pass
 #end try
-	<body$body_attr>
-		<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
-			<div class="container-fluid">
-				<div class="navbar-header">
-					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-						<span class="sr-only">Toggle navigation</span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</button>
-					<a href="$sbRoot/home/" class="navbar-brand" tabindex="-1" title="SickGear"><img alt="SickGear" src="$sbRoot/images/sickgear.png" style="height: 50px;" class="img-responsive pull-left" /></a>
-				</div>
+<body$body_attr>
+	<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+		<div class="container-fluid">
 
-				<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-					<ul class="nav navbar-nav navbar-right">
-						<li id="NAVhome" class="dropdown">
-							<a href="$sbRoot/home/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">Shows <b class="caret"></b></a>
-							<ul class="dropdown-menu">
-								<li><a href="$sbRoot/home/showlistView/" tabindex="$tab#set $tab += 1#"><i class="sgicon-home"></i>&nbsp;Show List</a></li>
-								<li><a href="$sbRoot/home/addShows/" tabindex="$tab#set $tab += 1#"><i class="sgicon-addshow"></i>&nbsp;Add Shows</a></li>
-								<li><a href="$sbRoot/home/postprocess/" tabindex="$tab#set $tab += 1#"><i class="sgicon-postprocess"></i>&nbsp;Manual Post-Processing</a></li>
-							</ul>
-						</li>
+			<div class="navbar-header">
+				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+					<span class="sr-only">Toggle navigation</span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+				</button>
+				<a href="$sbRoot/home/" class="navbar-brand" tabindex="-1" title="SickGear"><img alt="SickGear" src="$sbRoot/images/sickgear.png" style="height: 50px;" class="img-responsive pull-left" /></a>
+			</div>
 
-						<li id="NAVepisodeView">
-							<a href="$sbRoot/episodeView/" tabindex="$tab#set $tab += 1#">Episodes</a>
-						</li>
+			<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+				<ul class="nav navbar-nav navbar-right">
+					<li id="NAVhome" class="dropdown">
+						<a href="$sbRoot/home/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">Shows <b class="caret"></b></a>
+						<ul class="dropdown-menu">
+							<li><a href="$sbRoot/home/showlistView/" tabindex="$tab#set $tab += 1#"><i class="sgicon-home"></i>Show List</a></li>
+							<li><a href="$sbRoot/home/addShows/" tabindex="$tab#set $tab += 1#"><i class="sgicon-addshow"></i>Add Shows</a></li>
+							<li><a href="$sbRoot/home/postprocess/" tabindex="$tab#set $tab += 1#"><i class="sgicon-postprocess"></i>Manual Post-Processing</a></li>
+						</ul>
+					</li>
 
-						<li id="NAVhistory">
-							<a href="$sbRoot/history/" tabindex="$tab#set $tab += 1#">History</a>
-						</li>
+					<li id="NAVepisodeView">
+						<a href="$sbRoot/episodeView/" tabindex="$tab#set $tab += 1#">Episodes</a>
+					</li>
 
-						<li id="NAVmanage" class="dropdown">
-							<a href="$sbRoot/manage/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">Manage <b class="caret"></b></a>
-							<ul class="dropdown-menu">
-								<li><a href="$sbRoot/manage/" tabindex="$tab#set $tab += 1#"><i class="sgicon-massupdate"></i>&nbsp;Mass Update</a></li>
-								<li><a href="$sbRoot/manage/backlogOverview/" tabindex="$tab#set $tab += 1#"><i class="sgicon-backlog"></i>&nbsp;Backlog Overview</a></li>
-								<li><a href="$sbRoot/manage/manageSearches/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>&nbsp;Manage Searches</a></li>
-								<li><a href="$sbRoot/manage/episodeStatuses/" tabindex="$tab#set $tab += 1#"><i class="sgicon-episodestatus"></i>&nbsp;Episode Status Management</a></li>
-#if $sickbeard.USE_PLEX and $sickbeard.PLEX_SERVER_HOST != '':
-								<li><a href="$sbRoot/home/updatePLEX/" tabindex="$tab#set $tab += 1#"><i class="sgicon-plex"></i>&nbsp;Update PLEX</a></li>
+					<li id="NAVhistory">
+						<a href="$sbRoot/history/" tabindex="$tab#set $tab += 1#">History</a>
+					</li>
+
+					<li id="NAVmanage" class="dropdown">
+						<a href="$sbRoot/manage/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">Manage <b class="caret"></b></a>
+						<ul class="dropdown-menu">
+							<li><a href="$sbRoot/manage/" tabindex="$tab#set $tab += 1#"><i class="sgicon-massupdate"></i>Mass Update</a></li>
+							<li><a href="$sbRoot/manage/backlogOverview/" tabindex="$tab#set $tab += 1#"><i class="sgicon-backlog"></i>Backlog Overview</a></li>
+							<li><a href="$sbRoot/manage/manageSearches/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>Manage Searches</a></li>
+							<li><a href="$sbRoot/manage/episodeStatuses/" tabindex="$tab#set $tab += 1#"><i class="sgicon-episodestatus"></i>Episode Status Management</a></li>
+#if $sickbeard.USE_PLEX and $sickbeard.PLEX_SERVER_HOST != ''
+							<li><a href="$sbRoot/home/updatePLEX/" tabindex="$tab#set $tab += 1#"><i class="sgicon-plex"></i>Update PLEX</a></li>
 #end if
-#if $sickbeard.USE_XBMC and $sickbeard.XBMC_HOST != '':
-								<li><a href="$sbRoot/home/updateXBMC/" tabindex="$tab#set $tab += 1#"><i class="sgicon-xbmc"></i>&nbsp;Update XBMC</a></li>
+#if $sickbeard.USE_XBMC and $sickbeard.XBMC_HOST != ''
+							<li><a href="$sbRoot/home/updateXBMC/" tabindex="$tab#set $tab += 1#"><i class="sgicon-xbmc"></i>Update XBMC</a></li>
 #end if
-#if $sickbeard.USE_KODI and $sickbeard.KODI_HOST != '':
-								<li><a href="$sbRoot/home/updateKODI/" tabindex="$tab#set $tab += 1#"><i class="sgicon-kodi"></i>&nbsp;Update Kodi</a></li>
+#if $sickbeard.USE_KODI and $sickbeard.KODI_HOST != ''
+							<li><a href="$sbRoot/home/updateKODI/" tabindex="$tab#set $tab += 1#"><i class="sgicon-kodi"></i>Update Kodi</a></li>
 #end if
 #if $sickbeard.USE_TORRENTS and $sickbeard.TORRENT_METHOD != 'blackhole' \
     and ($sickbeard.ENABLE_HTTPS and $sickbeard.TORRENT_HOST[:5] == 'https' \
-    or not $sickbeard.ENABLE_HTTPS and $sickbeard.TORRENT_HOST[:5] == 'http:'):
-								<li><a href="$sbRoot/manage/manageTorrents/" tabindex="$tab#set $tab += 1#"><i class="sgicon-bittorrent"></i>&nbsp;Manage Torrents</a></li>
+    or not $sickbeard.ENABLE_HTTPS and $sickbeard.TORRENT_HOST[:5] == 'http:')
+							<li><a href="$sbRoot/manage/manageTorrents/" tabindex="$tab#set $tab += 1#"><i class="sgicon-bittorrent"></i>Manage Torrents</a></li>
 #end if
-#if $sickbeard.USE_FAILED_DOWNLOADS:
-								<li><a href="$sbRoot/manage/failedDownloads/" tabindex="$tab#set $tab += 1#"><i class="sgicon-failed"></i>&nbsp;Failed Downloads</a></li>
+#if $sickbeard.USE_FAILED_DOWNLOADS
+							<li><a href="$sbRoot/manage/failedDownloads/" tabindex="$tab#set $tab += 1#"><i class="sgicon-failed"></i>Failed Downloads</a></li>
 #end if
-#if $sickbeard.USE_SUBTITLES:
-								<li><a href="$sbRoot/manage/subtitleMissed/" tabindex="$tab#set $tab += 1#"><i class="sgicon-subtitles"></i>&nbsp;Missed Subtitle Management</a></li>
+#if $sickbeard.USE_SUBTITLES
+							<li><a href="$sbRoot/manage/subtitleMissed/" tabindex="$tab#set $tab += 1#"><i class="sgicon-subtitles"></i>Missed Subtitle Management</a></li>
 #end if
-							</ul>
-						</li>
+						</ul>
+					</li>
 
-						<li id="NAVerrorlogs" class="dropdown">
-							<a href="$sbRoot/errorlogs/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">$logPageTitle <b class="caret"></b></a>
-							<ul class="dropdown-menu">
-								<li><a href="$sbRoot/errorlogs/" tabindex="$tab#set $tab += 1#"><i class="sgicon-errorlog"></i>&nbsp;View Log (Errors)</a></li>
-								<li><a href="$sbRoot/errorlogs/viewlog/" tabindex="$tab#set $tab += 1#"><i class="sgicon-log"></i>&nbsp;View Log</a></li>
-							</ul>
-						</li>
+					<li id="NAVerrorlogs" class="dropdown">
+						<a href="$sbRoot/errorlogs/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#">$logPageTitle <b class="caret"></b></a>
+						<ul class="dropdown-menu">
+							<li><a href="$sbRoot/errorlogs/" tabindex="$tab#set $tab += 1#"><i class="sgicon-errorlog"></i>View Log (Errors)</a></li>
+							<li><a href="$sbRoot/errorlogs/viewlog/" tabindex="$tab#set $tab += 1#"><i class="sgicon-log"></i>View Log</a></li>
+						</ul>
+					</li>
 
-						<li id="NAVconfig" class="dropdown">
-							<a href="$sbRoot/config/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#"><img src="$sbRoot/images/menu/system18.png" class="navbaricon hidden-xs" /><b class="caret hidden-xs"></b><span class="visible-xs">Config <b class="caret"></b></span></a>
-							<ul class="dropdown-menu">
-								<li><a href="$sbRoot/config/" tabindex="$tab#set $tab += 1#"><i class="sgicon-info"></i>&nbsp;Help &amp; Info</a></li>
-								<li><a href="$sbRoot/config/general/" tabindex="$tab#set $tab += 1#"><i class="sgicon-config"></i>&nbsp;General</a></li>
-								<li><a href="$sbRoot/config/search/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>&nbsp;Search Settings</a></li>
-								<li><a href="$sbRoot/config/providers/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>&nbsp;Search Providers</a></li>
-								<li><a href="$sbRoot/config/subtitles/" tabindex="$tab#set $tab += 1#"><i class="sgicon-subtitles"></i>&nbsp;Subtitles Settings</a></li>
-								<li><a href="$sbRoot/config/postProcessing/" tabindex="$tab#set $tab += 1#"><i class="sgicon-postprocess"></i>&nbsp;Post Processing</a></li>
-								<li><a href="$sbRoot/config/notifications/" tabindex="$tab#set $tab += 1#"><i class="sgicon-notification"></i>&nbsp;Notifications</a></li>
-								<li><a href="$sbRoot/config/anime/" tabindex="$tab#set $tab += 1#"><i class="sgicon-anime"></i>&nbsp;Anime</a></li>
-							</ul>
-						</li>
+					<li id="NAVconfig" class="dropdown">
+						<a href="$sbRoot/config/" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#"><img src="$sbRoot/images/menu/system18.png" class="navbaricon hidden-xs" /><b class="caret hidden-xs"></b><span class="visible-xs">Config <b class="caret"></b></span></a>
+						<ul class="dropdown-menu">
+							<li><a href="$sbRoot/config/" tabindex="$tab#set $tab += 1#"><i class="sgicon-info"></i>Help &amp; Info</a></li>
+							<li><a href="$sbRoot/config/general/" tabindex="$tab#set $tab += 1#"><i class="sgicon-config"></i>General</a></li>
+							<li><a href="$sbRoot/config/search/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>Search Settings</a></li>
+							<li><a href="$sbRoot/config/providers/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>Search Providers</a></li>
+							<li><a href="$sbRoot/config/providers/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>Search Providers</a></li>
+							<li><a href="$sbRoot/config/subtitles/" tabindex="$tab#set $tab += 1#"><i class="sgicon-subtitles"></i>Subtitles Settings</a></li>
+							<li><a href="$sbRoot/config/postProcessing/" tabindex="$tab#set $tab += 1#"><i class="sgicon-postprocess"></i>Post Processing</a></li>
+							<li><a href="$sbRoot/config/notifications/" tabindex="$tab#set $tab += 1#"><i class="sgicon-notification"></i>Notifications</a></li>
+							<li><a href="$sbRoot/config/anime/" tabindex="$tab#set $tab += 1#"><i class="sgicon-anime"></i>Anime</a></li>
+						</ul>
+					</li>
 
-						<li class="dropdown">
-							<a href="#" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#"><img src="$sbRoot/images/menu/system18-2.png" class="navbaricon hidden-xs" /><b class="caret hidden-xs"></b><span class="visible-xs">System <b class="caret"></b></span></a>
-							<ul class="dropdown-menu">
-								<li><a href="$sbRoot/manage/manageSearches/forceVersionCheck" tabindex="$tab#set $tab += 1#"><i class="sgicon-updatecheck"></i>&nbsp;Force Version Check</a></li>
-								#if $sickbeard.WEB_USERNAME or $sickbeard.WEB_PASSWORD:
-									<li><a href="$sbRoot/logout" class="confirm logout" tabindex="$tab#set $tab += 1#"><i class="sgicon-logout"></i>&nbsp;Logout</a></li>
-								#end if
-								<li><a href="$sbRoot/home/restart/?pid=$sbPID" class="confirm restart" tabindex="$tab#set $tab += 1#"><i class="sgicon-restart"></i>&nbsp;Restart</a></li>
-								<li><a href="$sbRoot/home/shutdown/?pid=$sbPID" class="confirm shutdown" tabindex="$tab#set $tab += 1#"><i class="sgicon-shutdown"></i>&nbsp;Shutdown</a></li>
-							</ul>
-						</li>
-					</ul>
+					<li class="dropdown">
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown" data-delay="0" tabindex="$tab#set $tab += 1#"><img src="$sbRoot/images/menu/system18-2.png" class="navbaricon hidden-xs" /><b class="caret hidden-xs"></b><span class="visible-xs">System <b class="caret"></b></span></a>
+						<ul class="dropdown-menu">
+							<li><a href="$sbRoot/manage/manageSearches/forceVersionCheck" tabindex="$tab#set $tab += 1#"><i class="sgicon-updatecheck"></i>Force Version Check</a></li>
+#if $sickbeard.WEB_USERNAME or $sickbeard.WEB_PASSWORD
+								<li><a href="$sbRoot/logout" class="confirm logout" tabindex="$tab#set $tab += 1#"><i class="sgicon-logout"></i>Logout</a></li>
+#end if
+							<li><a href="$sbRoot/home/restart/?pid=$sbPID" class="confirm restart" tabindex="$tab#set $tab += 1#"><i class="sgicon-restart"></i>Restart</a></li>
+							<li><a href="$sbRoot/home/shutdown/?pid=$sbPID" class="confirm shutdown" tabindex="$tab#set $tab += 1#"><i class="sgicon-shutdown"></i>Shutdown</a></li>
+						</ul>
+					</li>
+				</ul>
+			</div><!-- /.navbar-collapse -->
 
-				</div><!-- /.navbar-collapse -->
-			</div><!-- /.container-fluid -->
-		</nav>
+		</div><!-- /.container-fluid -->
+	</nav>
 
-#if $varExists('submenu'):
-		<div id="SubMenu">
-			<span>
-        #set $first = True
-        #for $menuItem in $submenu:
-            #if 'requires' not in $menuItem or $menuItem.requires():
-                #if type($menuItem.path) == dict:
-                    #if $first then "" else "</span><span>"#<b>$menuItem.title</b>
-                    #set $first = False
-                    #set $inner_first = True
-                    #for $cur_link in $menuItem.path:
-                        #if $inner_first then "" else "&middot; "#<a class="inner" href="$sbRoot/$menuItem.path[$cur_link]">$cur_link</a>
-                        #set $inner_first = False
-                    #end for
-                #else
-                    #if $first then "" else ""#<a href="$sbRoot/$menuItem.path" #if 'confirm' in $menuItem then "class=\"confirm\"" else "" # tabindex="$tab#set $tab += 1#">$menuItem.title</a>
-                    #set $first = False
-                #end if
+#if $varExists('submenu')
+	<div id="SubMenu">
+		<span>
+    #set $first = True
+    #for $menuItem in $submenu
+        #if 'requires' not in $menuItem or $menuItem.requires()
+            #if type($menuItem.path) == dict
+                #if $first then '' else '</span><span>'#<b>$menuItem.title</b>
+                #set $first = False
+                #set $inner_first = True
+                #for $cur_link in $menuItem.path
+                    #if $inner_first then '' else '&middot; '
+                    #slurp
+			<a class="inner" href="$sbRoot/$menuItem.path[$cur_link]">$cur_link</a>
+                    #set $inner_first = False
+                #end for
+            #else
+                #slurp
+			<a href="$sbRoot/$menuItem.path"#if 'confirm' in $menuItem then ' class="confirm"' else ''# tabindex="$tab#set $tab += 1#">$menuItem.title</a>
+                #set $first = False
             #end if
-        #end for
-			</span>
-		</div>
+        #end if
+    #end for
+		</span>
+	</div>
 #end if
-
-#if $sickbeard.NEWEST_VERSION_STRING:
-		<div class="alert alert-success upgrade-notification" role="alert">
-			<span>$sickbeard.NEWEST_VERSION_STRING</span>
-		</div>
+##
+#if $sickbeard.NEWEST_VERSION_STRING
+	<div class="alert alert-success upgrade-notification" role="alert">
+		<span>$sickbeard.NEWEST_VERSION_STRING</span>
+	</div>
 #end if
-
+##
 #set $items = []
 #try
     $items.append($topmenu)
-#except (NameError, NotFound):
+#except (NameError, NotFound)
     #pass
 #end try
 #try
     $items.append($layout)
-#except (NameError, NotFound):
+#except (NameError, NotFound)
     #pass
 #end try
 #set $page_class = ('', ' class="%s"' % '_'.join($items).lower().replace(' ', '-').replace('_', '-'))[0 < len($items)]
-		<div id="contentWrapper">
-			<div id="content"$page_class>
+	<div id="contentWrapper">
+		<div id="content"$page_class>

--- a/gui/slick/interfaces/default/manage_massEdit.tmpl
+++ b/gui/slick/interfaces/default/manage_massEdit.tmpl
@@ -165,12 +165,12 @@
 	</div>
 
 	<div class="optionWrapper #if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then 'hidden' else ''#">
-		<span class="selectTitle">Tag</span>
+		<span class="selectTitle">Show is grouped in</span>
 		<div class="selectChoices">
 			<select id="edit_tag" name="tag" class="form-control form-control-inline input-sm">
 				<option value="keep">&lt; keep &gt;</option>
 #for $tag in $sickbeard.SHOW_TAGS:
-				<option value="$tag" #if $tag_value == $tag then $selected else ''#>$tag</option>
+				<option value="$tag" #if $tag_value == $tag then $selected else ''#>$tag#echo ('', ' (default)')['Show List' == $tag]#</option>
 #end for
 			</select>
 		</div><br />

--- a/gui/slick/js/config.js
+++ b/gui/slick/js/config.js
@@ -121,6 +121,15 @@ $(document).ready(function () {
 
 	fetch_branches();
 	fetch_pullrequests();
+
+	$('#showlist_tagview').on('change', function() {
+		var selected = '#showlist_tagview_', target = $(selected + 'custom_config');
+		target.removeClass('hidden');
+		if ('custom' !== $(this).val())
+			target.addClass('hidden');
+		$(selected + 'standard,' + selected + 'anime,' + selected + 'custom').removeClass('hidden').addClass('hidden');
+		$(selected + $(this).val()).removeClass('hidden');
+	});
 });
 
 function config_success(response) {

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -743,6 +743,7 @@ class ConfigMigrator():
     def _migrate_v10(self):
         # reset backlog frequency to default
         sickbeard.BACKLOG_FREQUENCY = sickbeard.DEFAULT_BACKLOG_FREQUENCY
+
     def _migrate_v11(self):
         if check_setting_int(self.config_obj, 'ANIME', 'anime_split_home', ''):
             sickbeard.SHOWLIST_TAGVIEW = 'anime'


### PR DESCRIPTION
* The bug resulted in the db containing stale group names but worse, orphaned shows disappeared from the Show List page entirely
* PEP8 and code cleanup to SG conventions
* Changed texts to describe this feature more clearly from tag to group names
* Repositioned this feature on the add show, edit show, and config pages
* Change the drop down select to dynamically hide/show the list of group names and change the respectively selected help texts
* Change insert space between items in the list of group names for readability
* Notify user if an attempt to remove an in use group name is prevented
* Change Show List progress bar code, smaller page load, efficient use of js render engine
* Removed fixed column widths, this means multiple groups have different column widths, but the original approach is preferred because fixed widths look bad with long show titles
