### PR TITLE
Add handling for shows that do not have a total number of episodes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 * Change to prevent another scheduled search when one of the same type is already running
 * Add custom show lists to home page
 * Change travis to new container builds for faster unit testing
+* Add handling for shows that do not have a total number of episodes
 * Change values used for date sorting on home page and episode view for improved compatibility with posix systems
 
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1131,7 +1131,8 @@ class Home(MainHandler):
             if highest_season < curResult['season'] and 1000 < curResult['airdate'] and UNAIRED < curResult['status']:
                 highest_season = curResult['season']
 
-        latest_season = int(sorted(epCounts['totals'])[-1::][0])
+        if 0 < len(epCounts['totals']):
+            latest_season = int(sorted(epCounts['totals'])[-1::][0])
 
         display_seasons = []
         if 1 < highest_season:


### PR DESCRIPTION
For rare case where a show can be in the db and added to the indexer and then the episodes removed from the indexer but not the show.