### PR TITLE
Show and Search Queue changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-﻿### 0.x.x (2015-xx-xx xx:xx:xx UTC)
+### 0.x.x (2015-xx-xx xx:xx:xx UTC)
 
 * Update Tornado webserver to 4.2.dev1 (609dbb9)
 * Update change to suppress reporting of Tornado exception error 1 to updated package as listed in hacks.txt
@@ -49,6 +49,16 @@
 * Add clarity to the output of a successful post process but with some issues rather than "there were problems"
 * Add a conclusive bottom line to the pp result report
 * Change helpers doctests to unittests
+* Add Search Queue Overview page
+* Add expandable search queue details on the Manage Searches page
+* Fix failed status episodes not included in next_episode search function
+* Change prevent another show update from running if one is already running
+* Change split Force backlog button on the Manage Searches page into: Force Limited, Force Full
+* Change refactor properFinder to be part of the search
+* Change improve threading of generic_queue, show_queue and search_queue
+* Change disable the Force buttons on the Manage Searches page while a search is running
+* Change disable the Pause buttons on the Manage Searches page if a search is not running
+* Change staggered periods of testing and updating of all shows "ended" status up to 460 days
 
 [develop changelog]
 * Fix issue, when adding existing shows, set its default group to ensure it now appears on the show list page

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -442,6 +442,7 @@ inc_top.tmpl
 	content:"\e613"
 }
 
+.sgicon-showqueue:before,
 .sgicon-refresh:before{
 	content:"\e614"
 }

--- a/gui/slick/interfaces/default/inc_top.tmpl
+++ b/gui/slick/interfaces/default/inc_top.tmpl
@@ -102,6 +102,7 @@
 			$('#SubMenu a:contains("Processing")').addClass('btn').html('<i class="sgicon-postprocess"></i>Post-Processing');
 			$('#SubMenu a:contains("Manage Searches")').addClass('btn').html('<i class="sgicon-search"></i>Manage Searches');
 			$('#SubMenu a:contains("Manage Torrents")').addClass('btn').html('<i class="sgicon-bittorrent"></i>Manage Torrents');
+			$('#SubMenu a:contains("Show Queue Overview")').addClass('btn').html('<i class="sgicon-showqueue"></i>Show Queue Overview');
 			$('#SubMenu a[href$="/manage/failedDownloads/"]').addClass('btn').html('<i class="sgicon-failed"></i>Failed Downloads');
 			$('#SubMenu a:contains("Notification")').addClass('btn').html('<i class="sgicon-notification"></i>Notifications');
 			$('#SubMenu a:contains("Update show in XBMC")').addClass('btn').html('<i class="sgicon-xbmc"></i>Update show in XBMC');
@@ -166,6 +167,7 @@
 							<li><a href="$sbRoot/manage/" tabindex="$tab#set $tab += 1#"><i class="sgicon-massupdate"></i>Mass Update</a></li>
 							<li><a href="$sbRoot/manage/backlogOverview/" tabindex="$tab#set $tab += 1#"><i class="sgicon-backlog"></i>Backlog Overview</a></li>
 							<li><a href="$sbRoot/manage/manageSearches/" tabindex="$tab#set $tab += 1#"><i class="sgicon-search"></i>Manage Searches</a></li>
+							<li><a href="$sbRoot/manage/showQueueOverview/" tabindex="$tab#set $tab += 1#"><i class="sgicon-showqueue"></i>Show Queue Overview</a></li>
 							<li><a href="$sbRoot/manage/episodeStatuses/" tabindex="$tab#set $tab += 1#"><i class="sgicon-episodestatus"></i>Episode Status Management</a></li>
 #if $sickbeard.USE_PLEX and $sickbeard.PLEX_SERVER_HOST != ''
 							<li><a href="$sbRoot/home/updatePLEX/" tabindex="$tab#set $tab += 1#"><i class="sgicon-plex"></i>Update PLEX</a></li>

--- a/gui/slick/interfaces/default/manage_manageSearches.tmpl
+++ b/gui/slick/interfaces/default/manage_manageSearches.tmpl
@@ -1,6 +1,4 @@
 #import sickbeard
-#import datetime
-#from sickbeard.common import *
 ##
 #set global $title = 'Manage Searches'
 #set global $header = 'Manage Searches'
@@ -11,6 +9,7 @@
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 
 <script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
+<script type="text/javascript" src="$sbRoot/js/manageSearches.js?$sbPID"></script>
 <div id="content800">
 #if $varExists('header')
 	<h1 class="header">$header</h1>
@@ -20,18 +19,19 @@
 
 	<div id="summary2" class="align-left">
 		<h3>Backlog Search:</h3>
-		<a class="btn" href="$sbRoot/manage/manageSearches/forceBacklog"><i class="sgicon-play"></i> Force</a>
-		<a class="btn" href="$sbRoot/manage/manageSearches/pauseBacklog?paused=#if $backlogPaused then '0' else '1'#"><i class="#if $backlogPaused then 'sgicon-play' else 'sgicon-pause'#"></i> #if $backlogPaused then 'Unpause' else 'Pause'#</a>
+		<a id="forcebacklog" class="btn#if $backlogRunning# disabled#end if#" href="$sbRoot/manage/manageSearches/forceLimitedBacklog"><i class="sgicon-play"></i> Force Limited</a>
+		<a id="forcefullbacklog" class="btn#if $backlogRunning# disabled#end if#" href="$sbRoot/manage/manageSearches/forceFullBacklog"><i class="sgicon-play"></i> Force Full</a>
+		<a id="pausebacklog" class="btn#if not $backlogRunning# disabled#end if#" href="$sbRoot/manage/manageSearches/pauseBacklog?paused=#if $backlogPaused then "0" else "1"#"><i class="#if $backlogPaused then "sgicon-play" else "sgicon-pause"#"></i> #if $backlogPaused then "Unpause" else "Pause"#</a>
 #if not $backlogRunning:
 		Not in progress<br />
 #else
 	#if $backlogPaused then 'Paused: ' else ''#
-		Currently running<br />
-	#end if
+		Currently running ($backlogRunningType)<br />
+#end if
 		<br />
 
 		<h3>Recent Search:</h3>
-		<a class="btn" href="$sbRoot/manage/manageSearches/forceSearch"><i class="sgicon-play"></i> Force</a>
+		<a id="recentsearch" class="btn#if $recentSearchStatus# disabled#end if#" href="$sbRoot/manage/manageSearches/forceSearch"><i class="sgicon-play"></i> Force</a>
 #if not $recentSearchStatus
 		Not in progress<br />
 #else
@@ -40,23 +40,98 @@
 		<br />
 
 		<h3>Find Propers Search:</h3>
-		<a class="btn" href="$sbRoot/manage/manageSearches/forceFindPropers"><i class="sgicon-play"></i> Force</a>
+		<a id="propersearch" class="btn#if $findPropersStatus# disabled#end if#" href="$sbRoot/manage/manageSearches/forceFindPropers"><i class="sgicon-play"></i> Force</a>
 #if not $findPropersStatus
 		Not in progress<br />
 #else
 		In Progress<br />
 #end if
 		<br />
-	
+
 		<h3>Version Check:</h3>
 		<a class="btn" href="$sbRoot/manage/manageSearches/forceVersionCheck"><i class="sgicon-updatecheck"></i> Force Check</a>
 		<br /><br />
 	
 		<h3>Search Queue:</h3>
-		Backlog: <i>$queueLength['backlog'] pending items</i><br />
-		Recent: <i>$queueLength['recent'] pending items</i><br />
-		Manual: <i>$queueLength['manual'] pending items</i><br />
-		Failed: <i>$queueLength['failed'] pending items</i><br />
+#if $queueLength['backlog'] or $queueLength['manual'] or $queueLength['failed']
+		<input type="button" class="show-all-more btn" id="all-btn-more" value="Expand All"><input type="button" class="show-all-less btn" id="all-btn-less" value="Collapse All"></br>
+#end if
+</br>
+Recent: <i>$queueLength['recent'] item$sickbeard.helpers.maybe_plural($queueLength['recent'])</i></br></br>
+Proper: <i>$queueLength['proper'] item$sickbeard.helpers.maybe_plural($queueLength['proper'])</i></br></br>
+Backlog: <i>$len($queueLength['backlog']) item$sickbeard.helpers.maybe_plural($len($queueLength['backlog']))</i>
+#if $queueLength['backlog']
+	<input type="button" class="shows-more btn" id="backlog-btn-more" value="Expand" #if not $queueLength['backlog']# style="display:none" #end if#><input type="button" class="shows-less btn" id="backlog-btn-less" value="Collapse" style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_item in $queueLength['backlog']:
+			#set $search_type = 'On Demand'
+			#if $cur_item[3]:
+				#if $cur_item[5]:
+					#set $search_type = 'Forced'
+				#else
+					#set $search_type = 'Scheduled'
+				#end if
+				#if $cur_item[4]:
+					#set $search_type += ' (Limited)'
+				#else
+					#set $search_type += ' (Full)'
+				#end if
+			#end if
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:80%;text-align:left;color:white">
+					<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_item[0]">$cur_item[1]</a> - $sickbeard.helpers.make_search_segment_html_string($cur_item[2])
+				</td>
+				<td style="width:20%;text-align:center;color:white">$search_type</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
+</br>
+Manual: <i>$len($queueLength['manual']) item$sickbeard.helpers.maybe_plural($len($queueLength['manual']))</i>
+#if $queueLength['manual']
+	<input type="button" class="shows-more btn" id="manual-btn-more" value="Expand" #if not $queueLength['manual']# style="display:none" #end if#><input type="button" class="shows-less btn" id="manual-btn-less" value="Collapse" style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_item in $queueLength['manual']:
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:100%;text-align:left;color:white">
+					<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_item[0]">$cur_item[1]</a> - $sickbeard.helpers.make_search_segment_html_string($cur_item[2])
+				</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
+</br>
+Failed: <i>$len($queueLength['failed']) item$sickbeard.helpers.maybe_plural($len($queueLength['failed']))</i>
+#if $queueLength['failed']
+	<input type="button" class="shows-more btn" id="failed-btn-more" value="Expand" #if not $queueLength['failed']# style="display:none" #end if#><input type="button" class="shows-less btn" id="failed-btn-less" value="Collapse" style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_item in $queueLength['failed']:
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:100%;text-align:left;color:white">
+					<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_item[0]">$cur_item[1]</a> - $sickbeard.helpers.make_search_segment_html_string($cur_item[2])
+				</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
 	</div>
 </div>
 

--- a/gui/slick/interfaces/default/manage_showQueueOverview.tmpl
+++ b/gui/slick/interfaces/default/manage_showQueueOverview.tmpl
@@ -1,0 +1,151 @@
+#import sickbeard
+#from sickbeard.helpers import findCertainShow
+##
+#set global $title = 'Show Queue Overview'
+#set global $header = 'Show Queue Overview'
+#set global $sbPath = '..'
+#set global $topmenu = 'manage'
+##
+#import os.path
+#include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
+
+<script type="text/javascript" src="$sbRoot/js/manageShowQueueOverview.js?$sbPID" xmlns="http://www.w3.org/1999/html"></script>
+<div id="content800">
+#if $varExists('header')
+	<h1 class="header">$header</h1>
+#else
+	<h1 class="title">$title</h1>
+#end if
+
+<div id="summary2" class="align-left">
+<h3> Daily Show Update:</h3>
+<a id="showupdatebutton" class="btn#if $ShowUpdateRunning# disabled#end if#" href="$sbRoot/manage/showQueueOverview/forceShowUpdate"><i class="sgicon-play"></i> Force</a>
+#if not $ShowUpdateRunning:
+	Not in progress<br />
+#else:
+	Currently running<br />
+#end if
+</br>
+<h3>Show Queue:</h3>
+</br>
+#if $queueLength['add'] or $queueLength['update'] or $queueLength['refresh'] or $queueLength['rename'] or $queueLength['subtitle']
+	<input type="button" class="show-all-more btn" id="all-btn-more" value="Expand All"><input type="button" class="show-all-less btn" id="all-btn-less" value="Collapse All"></br>
+#end if
+</br>
+Add: <i>$len($queueLength['add']) show$sickbeard.helpers.maybe_plural($len($queueLength['add']))</i>
+#if $queueLength['add']
+	<input type="button" class="shows-more btn" id="add-btn-more" value="Expand" #if not $queueLength['add']# style="display:none" #end if#><input type="button" class="shows-less btn" id="add-btn-less" value="Collapse"  style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_show in $queueLength['add']:
+			#set $show_name = str($cur_show[0])
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:80%;text-align:left;color:white">$show_name</td>
+				<td style="width:20%;text-align:center;color:white">#if $cur_show[1]#Scheduled#end if#</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
+</br>
+Update <span class="grey-text">(Forced / Forced Web)</span>: <i>$len($queueLength['update']) <span class="grey-text">($len($queueLength['forceupdate']) / $len($queueLength['forceupdateweb']))</span> show$sickbeard.helpers.maybe_plural($len($queueLength['update']))</i>
+#if $queueLength['update']
+	<input type="button" class="shows-more btn" id="update-btn-more" value="Expand" #if not $queueLength['update']# style="display:none" #end if#><input type="button" class="shows-less btn" id="update-btn-less" value="Collapse" style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_show in $queueLength['update']:
+			#set $show = $findCertainShow($showList, $cur_show[0])
+			#set $show_name = $show.name if $show else str($cur_show[0])
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:80%;text-align:left">
+					<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_show[0]">$show_name</a>
+				</td>
+				<td style="width:20%;text-align:center;color:white">#if $cur_show[1]#Scheduled, #end if#$cur_show[2]</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
+</br>
+Refresh: <i>$len($queueLength['refresh']) show$sickbeard.helpers.maybe_plural($len($queueLength['refresh']))</i>
+#if $queueLength['refresh']
+	<input type="button" class="shows-more btn" id="refresh-btn-more" value="Expand" #if not $queueLength['refresh']# style="display:none" #end if#><input type="button" class="shows-less btn" id="refresh-btn-less" value="Collapse" style="display:none"></br>
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+		<thead></thead>
+		<tbody>
+		#set $row = 0
+		#for $cur_show in $queueLength['refresh']:
+			#set $show = $findCertainShow($showList, $cur_show[0])
+			#set $show_name = $show.name if $show else str($cur_show[0])
+			<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+				<td style="width:80%;text-align:left">
+					<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_show[0]">$show_name</a>
+				</td>
+				<td style="width:20%;text-align:center;color:white">#if $cur_show[1]#Scheduled#end if#</td>
+			</tr>
+		#end for
+		</tbody>
+	</table>
+#else
+	</br>
+#end if
+</br>
+Rename: <i>$len($queueLength['rename']) show$sickbeard.helpers.maybe_plural($len($queueLength['rename']))</i>
+#if $queueLength['rename']
+<input type="button" class="shows-more btn" id="rename-btn-more" value="Expand" #if not $queueLength['rename']# style="display:none" #end if#><input type="button" class="shows-less btn" id="rename-btn-less" value="Collapse" style="display:none"></br>
+
+	<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+	<thead></thead>
+	<tbody>
+	#set $row = 0
+	#for $cur_show in $queueLength['rename']:
+		#set $show = $findCertainShow($showList, $cur_show[0])
+		#set $show_name = $show.name if $show else str($cur_show[0])
+		<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+			<td style="width:80%;text-align:left">
+				<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_show[0]">$show_name</a>
+			</td>
+			<td style="width:20%;text-align:center;color:white">#if $cur_show[1]#Scheduled#end if#</td>
+		</tr>
+	#end for
+	</tbody>
+</table>
+#else
+	</br>
+#end if
+#if $sickbeard.USE_SUBTITLES
+	</br>
+	Subtitle: <i>$len($queueLength['subtitle']) show$sickbeard.helpers.maybe_plural($len($queueLength['subtitle']))</i>
+	#if $queueLength['subtitle']
+		<input type="button" class="shows-more btn" id="subtitle-btn-more" value="Expand" #if not $queueLength['subtitle']# style="display:none" #end if#><input type="button" class="shows-less btn" id="subtitle-btn-less" value="Collapse" style="display:none"></br>
+		<table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0" style="display:none">
+			<thead></thead>
+			<tbody>
+			#set $row = 0
+			#for $cur_show in $queueLength['subtitle']:
+				#set $show = $findCertainShow($showList, $cur_show[0])
+				#set $show_name = $show.name if $show else str($cur_show[0])
+				<tr class="#echo ('odd', 'even')[$row % 2]##set $row+=1#">
+					<td style="width:80%;text-align:left">
+						<a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_show[0]">$show_name</a>
+					</td>
+					<td style="width:20%;text-align:center;color:white">#if $cur_show[1]#Scheduled#end if#</td>
+				</tr>
+			#end for
+			</tbody>
+		</table>
+	#else
+		</br>
+	#end if
+#end if
+</div>
+</div>
+#include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_bottom.tmpl')

--- a/gui/slick/js/manageSearches.js
+++ b/gui/slick/js/manageSearches.js
@@ -1,0 +1,33 @@
+$(document).ready(function() { 
+	$('#recentsearch,#propersearch').click(function(){
+		$(this).addClass('disabled');
+	})
+	$('#forcebacklog,#forcefullbacklog').click(function(){
+		$('#forcebacklog,#forcefullbacklog').addClass('disabled');
+		$('#pausebacklog').removeClass('disabled');
+	})
+	$('#pausebacklog').click(function(){
+		$(this).addClass('disabled');
+	})
+	$('.show-all-less').click(function(){
+		$(this).nextAll('table').hide();
+		$(this).nextAll('input.shows-more').show();
+		$(this).nextAll('input.shows-less').hide();
+	})
+	$('.show-all-more').click(function(){
+		$(this).nextAll('table').show();
+		$(this).nextAll('input.shows-more').hide();
+		$(this).nextAll('input.shows-less').show();
+	})
+
+	$('.shows-less').click(function(){
+		$(this).nextAll('table:first').hide();
+		$(this).hide();
+		$(this).prevAll('input:first').show();
+	})
+	$('.shows-more').click(function(){
+		$(this).nextAll('table:first').show();
+		$(this).hide();
+		$(this).nextAll('input:first').show();
+	})
+});

--- a/gui/slick/js/manageShowQueueOverview.js
+++ b/gui/slick/js/manageShowQueueOverview.js
@@ -1,0 +1,26 @@
+$(document).ready(function() { 
+	$('#showupdatebutton').click(function(){
+		$(this).addClass('disabled');
+	})
+	$('.show-all-less').click(function(){
+		$(this).nextAll('table').hide();
+		$(this).nextAll('input.shows-more').show();
+		$(this).nextAll('input.shows-less').hide();
+	})
+	$('.show-all-more').click(function(){
+		$(this).nextAll('table').show();
+		$(this).nextAll('input.shows-more').hide();
+		$(this).nextAll('input.shows-less').show();
+	})
+
+	$('.shows-less').click(function(){
+		$(this).nextAll('table:first').hide();
+		$(this).hide();
+		$(this).prevAll('input:first').show();
+	})
+	$('.shows-more').click(function(){
+		$(this).nextAll('table:first').show();
+		$(this).hide();
+		$(this).nextAll('input:first').show();
+	})
+});

--- a/sickbeard/generic_queue.py
+++ b/sickbeard/generic_queue.py
@@ -35,69 +35,73 @@ class GenericQueue(object):
 
         self.queue = []
 
-        self.queue_name = "QUEUE"
+        self.queue_name = 'QUEUE'
 
         self.min_priority = 0
 
         self.lock = threading.Lock()
 
     def pause(self):
-        logger.log(u"Pausing queue")
-        self.min_priority = 999999999999
+        logger.log(u'Pausing queue')
+        if self.lock:
+            self.min_priority = 999999999999
 
     def unpause(self):
-        logger.log(u"Unpausing queue")
-        self.min_priority = 0
+        logger.log(u'Unpausing queue')
+        with self.lock:
+            self.min_priority = 0
 
     def add_item(self, item):
-        item.added = datetime.datetime.now()
-        self.queue.append(item)
+        with self.lock:
+            item.added = datetime.datetime.now()
+            self.queue.append(item)
 
-        return item
+            return item
 
     def run(self, force=False):
 
         # only start a new task if one isn't already going
-        if self.currentItem is None or not self.currentItem.isAlive():
+        with self.lock:
+            if self.currentItem is None or not self.currentItem.isAlive():
 
-            # if the thread is dead then the current item should be finished
-            if self.currentItem:
-                self.currentItem.finish()
-                self.currentItem = None
+                # if the thread is dead then the current item should be finished
+                if self.currentItem:
+                    self.currentItem.finish()
+                    self.currentItem = None
 
-            # if there's something in the queue then run it in a thread and take it out of the queue
-            if len(self.queue) > 0:
+                # if there's something in the queue then run it in a thread and take it out of the queue
+                if len(self.queue) > 0:
 
-                # sort by priority
-                def sorter(x, y):
-                    """
-                    Sorts by priority descending then time ascending
-                    """
-                    if x.priority == y.priority:
-                        if y.added == x.added:
-                            return 0
-                        elif y.added < x.added:
-                            return 1
-                        elif y.added > x.added:
-                            return -1
-                    else:
-                        return y.priority - x.priority
+                    # sort by priority
+                    def sorter(x, y):
+                        """
+                        Sorts by priority descending then time ascending
+                        """
+                        if x.priority == y.priority:
+                            if y.added == x.added:
+                                return 0
+                            elif y.added < x.added:
+                                return 1
+                            elif y.added > x.added:
+                                return -1
+                        else:
+                            return y.priority - x.priority
 
-                self.queue.sort(cmp=sorter)
-                if self.queue[0].priority < self.min_priority:
-                    return
+                    self.queue.sort(cmp=sorter)
+                    if self.queue[0].priority < self.min_priority:
+                        return
 
-                # launch the queue item in a thread
-                self.currentItem = self.queue.pop(0)
-                if not self.queue_name == 'SEARCHQUEUE':
-                    self.currentItem.name = self.queue_name + '-' + self.currentItem.name
-                self.currentItem.start()
+                    # launch the queue item in a thread
+                    self.currentItem = self.queue.pop(0)
+                    if not self.queue_name == 'SEARCHQUEUE':
+                        self.currentItem.name = self.queue_name + '-' + self.currentItem.name
+                    self.currentItem.start()
 
 class QueueItem(threading.Thread):
     def __init__(self, name, action_id=0):
         super(QueueItem, self).__init__()
 
-        self.name = name.replace(" ", "-").upper()
+        self.name = name.replace(' ', '-').upper()
         self.inProgress = False
         self.priority = QueuePriorities.NORMAL
         self.action_id = action_id

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1,4 +1,4 @@
-# Author: Nic Wolfe <nic@wolfeden.ca>
+﻿# Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #
 # This file is part of SickGear.
@@ -1412,3 +1412,21 @@ def clear_unused_providers():
     if providers:
         myDB = db.DBConnection('cache.db')
         myDB.action('DELETE FROM provider_cache WHERE provider NOT IN (%s)' % ','.join(['?'] * len(providers)), providers)
+
+def make_search_segment_html_string(segment, max_eps=5):
+    seg_str = ''
+    if segment and not isinstance(segment, list):
+        segment = [segment]
+    if segment and len(segment) > max_eps:
+        seasons = [x for x in set([x.season for x in segment])]
+        seg_str = u'Season' + maybe_plural(len(seasons)) + ': '
+        first_run = True
+        for x in seasons:
+            eps = [str(s.episode) for s in segment if s.season == x]
+            ep_c = len(eps)
+            seg_str += ('' if first_run else ' ,') + str(x) + ' <span title="Episode' + maybe_plural(ep_c) + ': ' + ', '.join(eps) + '">(' + str(ep_c) + ' Ep' + maybe_plural(ep_c) + ')</span>'
+            first_run = False
+    elif segment:
+        episodes = ['S' + str(x.season).zfill(2) + 'E' + str(x.episode).zfill(2) for x in segment]
+        seg_str = u'Episode' + maybe_plural(len(episodes)) + ': ' + ', '.join(episodes)
+    return seg_str

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -35,255 +35,247 @@ from sickbeard.common import DOWNLOADED, SNATCHED, SNATCHED_PROPER, Quality
 from name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 
 
-class ProperFinder():
-    def __init__(self):
-        self.amActive = False
+def searchPropers():
 
-    def run(self):
+    if not sickbeard.DOWNLOAD_PROPERS:
+        return
 
-        if not sickbeard.DOWNLOAD_PROPERS:
-            return
+    logger.log(u'Beginning the search for new propers')
 
-        logger.log(u"Beginning the search for new propers")
+    propers = _getProperList()
 
-        self.amActive = True
+    if propers:
+        _downloadPropers(propers)
 
-        propers = self._getProperList()
+    _set_lastProperSearch(datetime.datetime.today().toordinal())
 
-        if propers:
-            self._downloadPropers(propers)
+    run_at = ''
+    if None is sickbeard.properFinderScheduler.start_time:
+        run_in = sickbeard.properFinderScheduler.lastRun + sickbeard.properFinderScheduler.cycleTime - datetime.datetime.now()
+        hours, remainder = divmod(run_in.seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        run_at = u', next check in approx. ' + (
+            '%dh, %dm' % (hours, minutes) if 0 < hours else '%dm, %ds' % (minutes, seconds))
 
-        self._set_lastProperSearch(datetime.datetime.today().toordinal())
+    logger.log(u'Completed the search for new propers%s' % run_at)
 
-        run_at = ""
-        if None is sickbeard.properFinderScheduler.start_time:
-            run_in = sickbeard.properFinderScheduler.lastRun + sickbeard.properFinderScheduler.cycleTime - datetime.datetime.now()
-            hours, remainder = divmod(run_in.seconds, 3600)
-            minutes, seconds = divmod(remainder, 60)
-            run_at = u", next check in approx. " + (
-                "%dh, %dm" % (hours, minutes) if 0 < hours else "%dm, %ds" % (minutes, seconds))
+def _getProperList():
+    propers = {}
 
-        logger.log(u"Completed the search for new propers%s" % run_at)
+    search_date = datetime.datetime.today() - datetime.timedelta(days=2)
 
-        self.amActive = False
+    # for each provider get a list of the
+    origThreadName = threading.currentThread().name
+    providers = [x for x in sickbeard.providers.sortedProviderList() if x.isActive()]
+    for curProvider in providers:
+        threading.currentThread().name = origThreadName + ' :: [' + curProvider.name + ']'
 
-    def _getProperList(self):
-        propers = {}
+        logger.log(u'Searching for any new PROPER releases from ' + curProvider.name)
 
-        search_date = datetime.datetime.today() - datetime.timedelta(days=2)
+        try:
+            curPropers = curProvider.findPropers(search_date)
+        except exceptions.AuthException, e:
+            logger.log(u'Authentication error: ' + ex(e), logger.ERROR)
+            continue
+        except Exception, e:
+            logger.log(u'Error while searching ' + curProvider.name + ', skipping: ' + ex(e), logger.ERROR)
+            logger.log(traceback.format_exc(), logger.DEBUG)
+            continue
+        finally:
+            threading.currentThread().name = origThreadName
 
-        # for each provider get a list of the
-        origThreadName = threading.currentThread().name
-        providers = [x for x in sickbeard.providers.sortedProviderList() if x.isActive()]
-        for curProvider in providers:
-            threading.currentThread().name = origThreadName + " :: [" + curProvider.name + "]"
+        # if they haven't been added by a different provider than add the proper to the list
+        for x in curPropers:
+            name = _genericName(x.name)
+            if not name in propers:
+                logger.log(u'Found new proper: ' + x.name, logger.DEBUG)
+                x.provider = curProvider
+                propers[name] = x
 
-            logger.log(u"Searching for any new PROPER releases from " + curProvider.name)
+    # take the list of unique propers and get it sorted by
+    sortedPropers = sorted(propers.values(), key=operator.attrgetter('date'), reverse=True)
+    finalPropers = []
 
-            try:
-                curPropers = curProvider.findPropers(search_date)
-            except exceptions.AuthException, e:
-                logger.log(u"Authentication error: " + ex(e), logger.ERROR)
-                continue
-            except Exception, e:
-                logger.log(u"Error while searching " + curProvider.name + ", skipping: " + ex(e), logger.ERROR)
-                logger.log(traceback.format_exc(), logger.DEBUG)
-                continue
-            finally:
-                threading.currentThread().name = origThreadName
+    for curProper in sortedPropers:
 
-            # if they haven't been added by a different provider than add the proper to the list
-            for x in curPropers:
-                name = self._genericName(x.name)
-                if not name in propers:
-                    logger.log(u"Found new proper: " + x.name, logger.DEBUG)
-                    x.provider = curProvider
-                    propers[name] = x
+        try:
+            myParser = NameParser(False)
+            parse_result = myParser.parse(curProper.name)
+        except InvalidNameException:
+            logger.log(u'Unable to parse the filename ' + curProper.name + ' into a valid episode', logger.DEBUG)
+            continue
+        except InvalidShowException:
+            logger.log(u'Unable to parse the filename ' + curProper.name + ' into a valid show', logger.DEBUG)
+            continue
 
-        # take the list of unique propers and get it sorted by
-        sortedPropers = sorted(propers.values(), key=operator.attrgetter('date'), reverse=True)
-        finalPropers = []
+        if not parse_result.series_name:
+            continue
 
-        for curProper in sortedPropers:
-
-            try:
-                myParser = NameParser(False)
-                parse_result = myParser.parse(curProper.name)
-            except InvalidNameException:
-                logger.log(u"Unable to parse the filename " + curProper.name + " into a valid episode", logger.DEBUG)
-                continue
-            except InvalidShowException:
-                logger.log(u"Unable to parse the filename " + curProper.name + " into a valid show", logger.DEBUG)
-                continue
-
-            if not parse_result.series_name:
-                continue
-
-            if not parse_result.episode_numbers:
-                logger.log(
-                    u"Ignoring " + curProper.name + " because it's for a full season rather than specific episode",
-                    logger.DEBUG)
-                continue
-
+        if not parse_result.episode_numbers:
             logger.log(
-                u"Successful match! Result " + parse_result.original_name + " matched to show " + parse_result.show.name,
+                u'Ignoring ' + curProper.name + ' because it\'s for a full season rather than specific episode',
                 logger.DEBUG)
+            continue
 
-            # set the indexerid in the db to the show's indexerid
-            curProper.indexerid = parse_result.show.indexerid
+        logger.log(
+            u'Successful match! Result ' + parse_result.original_name + ' matched to show ' + parse_result.show.name,
+            logger.DEBUG)
 
-            # set the indexer in the db to the show's indexer
-            curProper.indexer = parse_result.show.indexer
+        # set the indexerid in the db to the show's indexerid
+        curProper.indexerid = parse_result.show.indexerid
 
-            # populate our Proper instance
-            curProper.season = parse_result.season_number if parse_result.season_number != None else 1
-            curProper.episode = parse_result.episode_numbers[0]
-            curProper.release_group = parse_result.release_group
-            curProper.version = parse_result.version
-            curProper.quality = Quality.nameQuality(curProper.name, parse_result.is_anime)
+        # set the indexer in the db to the show's indexer
+        curProper.indexer = parse_result.show.indexer
 
-            # only get anime proper if it has release group and version
-            if parse_result.is_anime:
-                if not curProper.release_group and curProper.version == -1:
-                    logger.log(u"Proper " + curProper.name + " doesn't have a release group and version, ignoring it",
-                               logger.DEBUG)
-                    continue
+        # populate our Proper instance
+        curProper.season = parse_result.season_number if parse_result.season_number != None else 1
+        curProper.episode = parse_result.episode_numbers[0]
+        curProper.release_group = parse_result.release_group
+        curProper.version = parse_result.version
+        curProper.quality = Quality.nameQuality(curProper.name, parse_result.is_anime)
 
-            if not show_name_helpers.filterBadReleases(curProper.name, parse=False):
-                logger.log(u"Proper " + curProper.name + " isn't a valid scene release that we want, ignoring it",
+        # only get anime proper if it has release group and version
+        if parse_result.is_anime:
+            if not curProper.release_group and curProper.version == -1:
+                logger.log(u'Proper ' + curProper.name + ' doesn\'t have a release group and version, ignoring it',
                            logger.DEBUG)
                 continue
 
-            if parse_result.show.rls_ignore_words and search.filter_release_name(curProper.name,
-                                                                                 parse_result.show.rls_ignore_words):
-                logger.log(
-                    u"Ignoring " + curProper.name + " based on ignored words filter: " + parse_result.show.rls_ignore_words,
-                    logger.MESSAGE)
-                continue
+        if not show_name_helpers.filterBadReleases(curProper.name, parse=False):
+            logger.log(u'Proper ' + curProper.name + ' isn\'t a valid scene release that we want, ignoring it',
+                       logger.DEBUG)
+            continue
 
-            if parse_result.show.rls_require_words and not search.filter_release_name(curProper.name,
-                                                                                      parse_result.show.rls_require_words):
-                logger.log(
-                    u"Ignoring " + curProper.name + " based on required words filter: " + parse_result.show.rls_require_words,
-                    logger.MESSAGE)
-                continue
+        if parse_result.show.rls_ignore_words and search.filter_release_name(curProper.name,
+                                                                             parse_result.show.rls_ignore_words):
+            logger.log(
+                u'Ignoring ' + curProper.name + ' based on ignored words filter: ' + parse_result.show.rls_ignore_words,
+                logger.MESSAGE)
+            continue
 
-            # check if we actually want this proper (if it's the right quality)
+        if parse_result.show.rls_require_words and not search.filter_release_name(curProper.name,
+                                                                                  parse_result.show.rls_require_words):
+            logger.log(
+                u'Ignoring ' + curProper.name + ' based on required words filter: ' + parse_result.show.rls_require_words,
+                logger.MESSAGE)
+            continue
+
+        # check if we actually want this proper (if it's the right quality)
+        myDB = db.DBConnection()
+        sqlResults = myDB.select('SELECT status FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
+                                 [curProper.indexerid, curProper.season, curProper.episode])
+        if not sqlResults:
+            continue
+
+        # only keep the proper if we have already retrieved the same quality ep (don't get better/worse ones)
+        oldStatus, oldQuality = Quality.splitCompositeStatus(int(sqlResults[0]['status']))
+        if oldStatus not in (DOWNLOADED, SNATCHED) or oldQuality != curProper.quality:
+            continue
+
+        # check if we actually want this proper (if it's the right release group and a higher version)
+        if parse_result.is_anime:
             myDB = db.DBConnection()
-            sqlResults = myDB.select("SELECT status FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?",
-                                     [curProper.indexerid, curProper.season, curProper.episode])
-            if not sqlResults:
-                continue
+            sqlResults = myDB.select(
+                'SELECT release_group, version FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
+                [curProper.indexerid, curProper.season, curProper.episode])
 
-            # only keep the proper if we have already retrieved the same quality ep (don't get better/worse ones)
-            oldStatus, oldQuality = Quality.splitCompositeStatus(int(sqlResults[0]["status"]))
-            if oldStatus not in (DOWNLOADED, SNATCHED) or oldQuality != curProper.quality:
-                continue
+            oldVersion = int(sqlResults[0]['version'])
+            oldRelease_group = (sqlResults[0]['release_group'])
 
-            # check if we actually want this proper (if it's the right release group and a higher version)
-            if parse_result.is_anime:
-                myDB = db.DBConnection()
-                sqlResults = myDB.select(
-                    "SELECT release_group, version FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?",
-                    [curProper.indexerid, curProper.season, curProper.episode])
-
-                oldVersion = int(sqlResults[0]["version"])
-                oldRelease_group = (sqlResults[0]["release_group"])
-
-                if oldVersion > -1 and oldVersion < curProper.version:
-                    logger.log("Found new anime v" + str(curProper.version) + " to replace existing v" + str(oldVersion))
-                else:
-                    continue
-
-                if oldRelease_group != curProper.release_group:
-                    logger.log("Skipping proper from release group: " + curProper.release_group + ", does not match existing release group: " + oldRelease_group)
-                    continue
-
-            # if the show is in our list and there hasn't been a proper already added for that particular episode then add it to our list of propers
-            if curProper.indexerid != -1 and (curProper.indexerid, curProper.season, curProper.episode) not in map(
-                    operator.attrgetter('indexerid', 'season', 'episode'), finalPropers):
-                logger.log(u"Found a proper that we need: " + str(curProper.name))
-                finalPropers.append(curProper)
-
-        return finalPropers
-
-    def _downloadPropers(self, properList):
-
-        for curProper in properList:
-
-            historyLimit = datetime.datetime.today() - datetime.timedelta(days=30)
-
-            # make sure the episode has been downloaded before
-            myDB = db.DBConnection()
-            historyResults = myDB.select(
-                "SELECT resource FROM history "
-                "WHERE showid = ? AND season = ? AND episode = ? AND quality = ? AND date >= ? "
-                "AND action IN (" + ",".join([str(x) for x in Quality.SNATCHED]) + ")",
-                [curProper.indexerid, curProper.season, curProper.episode, curProper.quality,
-                 historyLimit.strftime(history.dateFormat)])
-
-            # if we didn't download this episode in the first place we don't know what quality to use for the proper so we can't do it
-            if len(historyResults) == 0:
-                logger.log(
-                    u"Unable to find an original history entry for proper " + curProper.name + " so I'm not downloading it.")
-                continue
-
+            if oldVersion > -1 and oldVersion < curProper.version:
+                logger.log('Found new anime v' + str(curProper.version) + ' to replace existing v' + str(oldVersion))
             else:
+                continue
 
-                # make sure that none of the existing history downloads are the same proper we're trying to download
-                clean_proper_name = self._genericName(helpers.remove_non_release_groups(curProper.name))
-                isSame = False
-                for curResult in historyResults:
-                    # if the result exists in history already we need to skip it
-                    if self._genericName(helpers.remove_non_release_groups(curResult["resource"])) == clean_proper_name:
-                        isSame = True
-                        break
-                if isSame:
-                    logger.log(u"This proper is already in history, skipping it", logger.DEBUG)
-                    continue
+            if oldRelease_group != curProper.release_group:
+                logger.log('Skipping proper from release group: ' + curProper.release_group + ', does not match existing release group: ' + oldRelease_group)
+                continue
 
-                # get the episode object
-                showObj = helpers.findCertainShow(sickbeard.showList, curProper.indexerid)
-                if showObj == None:
-                    logger.log(u"Unable to find the show with indexerid " + str(
-                        curProper.indexerid) + " so unable to download the proper", logger.ERROR)
-                    continue
-                epObj = showObj.getEpisode(curProper.season, curProper.episode)
+        # if the show is in our list and there hasn't been a proper already added for that particular episode then add it to our list of propers
+        if curProper.indexerid != -1 and (curProper.indexerid, curProper.season, curProper.episode) not in map(
+                operator.attrgetter('indexerid', 'season', 'episode'), finalPropers):
+            logger.log(u'Found a proper that we need: ' + str(curProper.name))
+            finalPropers.append(curProper)
 
-                # make the result object
-                result = curProper.provider.getResult([epObj])
-                result.url = curProper.url
-                result.name = curProper.name
-                result.quality = curProper.quality
-                result.version = curProper.version
+    return finalPropers
 
-                # snatch it
-                search.snatchEpisode(result, SNATCHED_PROPER)
+def _downloadPropers(properList):
 
-    def _genericName(self, name):
-        return name.replace(".", " ").replace("-", " ").replace("_", " ").lower()
+    for curProper in properList:
 
-    def _set_lastProperSearch(self, when):
+        historyLimit = datetime.datetime.today() - datetime.timedelta(days=30)
 
-        logger.log(u"Setting the last Proper search in the DB to " + str(when), logger.DEBUG)
-
+        # make sure the episode has been downloaded before
         myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT * FROM info")
+        historyResults = myDB.select(
+            'SELECT resource FROM history '
+            'WHERE showid = ? AND season = ? AND episode = ? AND quality = ? AND date >= ? '
+            'AND action IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')',
+            [curProper.indexerid, curProper.season, curProper.episode, curProper.quality,
+             historyLimit.strftime(history.dateFormat)])
 
-        if len(sqlResults) == 0:
-            myDB.action("INSERT INTO info (last_backlog, last_indexer, last_proper_search) VALUES (?,?,?)",
-                        [0, 0, str(when)])
+        # if we didn't download this episode in the first place we don't know what quality to use for the proper so we can't do it
+        if len(historyResults) == 0:
+            logger.log(
+                u'Unable to find an original history entry for proper ' + curProper.name + ' so I\'m not downloading it.')
+            continue
+
         else:
-            myDB.action("UPDATE info SET last_proper_search=" + str(when))
 
-    def _get_lastProperSearch(self):
+            # make sure that none of the existing history downloads are the same proper we're trying to download
+            clean_proper_name = _genericName(helpers.remove_non_release_groups(curProper.name))
+            isSame = False
+            for curResult in historyResults:
+                # if the result exists in history already we need to skip it
+                if _genericName(helpers.remove_non_release_groups(curResult['resource'])) == clean_proper_name:
+                    isSame = True
+                    break
+            if isSame:
+                logger.log(u'This proper is already in history, skipping it', logger.DEBUG)
+                continue
 
-        myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT * FROM info")
+            # get the episode object
+            showObj = helpers.findCertainShow(sickbeard.showList, curProper.indexerid)
+            if showObj == None:
+                logger.log(u'Unable to find the show with indexerid ' + str(
+                    curProper.indexerid) + ' so unable to download the proper', logger.ERROR)
+                continue
+            epObj = showObj.getEpisode(curProper.season, curProper.episode)
 
-        try:
-            last_proper_search = datetime.date.fromordinal(int(sqlResults[0]["last_proper_search"]))
-        except:
-            return datetime.date.fromordinal(1)
+            # make the result object
+            result = curProper.provider.getResult([epObj])
+            result.url = curProper.url
+            result.name = curProper.name
+            result.quality = curProper.quality
+            result.version = curProper.version
 
-        return last_proper_search
+            # snatch it
+            search.snatchEpisode(result, SNATCHED_PROPER)
+
+def _genericName(name):
+    return name.replace('.', ' ').replace('-', ' ').replace('_', ' ').lower()
+
+def _set_lastProperSearch(when):
+
+    logger.log(u'Setting the last Proper search in the DB to ' + str(when), logger.DEBUG)
+
+    myDB = db.DBConnection()
+    sqlResults = myDB.select('SELECT * FROM info')
+
+    if len(sqlResults) == 0:
+        myDB.action('INSERT INTO info (last_backlog, last_indexer, last_proper_search) VALUES (?,?,?)',
+                    [0, 0, str(when)])
+    else:
+        myDB.action('UPDATE info SET last_proper_search=' + str(when))
+
+def _get_lastProperSearch():
+
+    myDB = db.DBConnection()
+    sqlResults = myDB.select('SELECT * FROM info')
+
+    try:
+        last_proper_search = datetime.date.fromordinal(int(sqlResults[0]['last_proper_search']))
+    except:
+        return datetime.date.fromordinal(1)
+
+    return last_proper_search

--- a/sickbeard/searchProper.py
+++ b/sickbeard/searchProper.py
@@ -1,0 +1,38 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of SickGear.
+#
+# SickGear is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SickGear is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SickGear.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import with_statement
+
+import threading
+
+import sickbeard
+
+
+class ProperSearcher():
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.amActive = False
+
+    def run(self):
+
+        self.amActive = True
+
+        propersearch_queue_item = sickbeard.search_queue.ProperSearchQueueItem()
+        sickbeard.searchQueueScheduler.action.add_item(propersearch_queue_item)
+
+        self.amActive = False

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -25,7 +25,7 @@ import datetime
 
 import sickbeard
 from sickbeard import db, logger, common, exceptions, helpers, network_timezones, generic_queue, search, \
-    failed_history, history, ui
+    failed_history, history, ui, properFinder
 from sickbeard.search import wantedEpisodes
 
 
@@ -35,6 +35,7 @@ BACKLOG_SEARCH = 10
 RECENT_SEARCH = 20
 FAILED_SEARCH = 30
 MANUAL_SEARCH = 40
+PROPER_SEARCH = 50
 
 MANUAL_SEARCH_HISTORY = []
 MANUAL_SEARCH_HISTORY_SIZE = 100
@@ -42,87 +43,122 @@ MANUAL_SEARCH_HISTORY_SIZE = 100
 class SearchQueue(generic_queue.GenericQueue):
     def __init__(self):
         generic_queue.GenericQueue.__init__(self)
-        self.queue_name = "SEARCHQUEUE"
+        self.queue_name = 'SEARCHQUEUE'
 
     def is_in_queue(self, show, segment):
-        for cur_item in self.queue:
-            if isinstance(cur_item, BacklogQueueItem) and cur_item.show == show and cur_item.segment == segment:
-                return True
-        return False
+        with self.lock:
+            for cur_item in self.queue:
+                if isinstance(cur_item, BacklogQueueItem) and cur_item.show == show and cur_item.segment == segment:
+                    return True
+            return False
 
     def is_ep_in_queue(self, segment):
-        for cur_item in self.queue:
-            if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and cur_item.segment == segment:
-                return True
-        return False
+        with self.lock:
+            for cur_item in self.queue:
+                if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and cur_item.segment == segment:
+                    return True
+            return False
     
     def is_show_in_queue(self, show):
-        for cur_item in self.queue:
-            if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and cur_item.show.indexerid == show:
-                return True
-        return False
+        with self.lock:
+            for cur_item in self.queue:
+                if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and cur_item.show.indexerid == show:
+                    return True
+            return False
     
     def get_all_ep_from_queue(self, show):
-        ep_obj_list = []
-        for cur_item in self.queue:
-            if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and str(cur_item.show.indexerid) == show:
-                ep_obj_list.append(cur_item)
-        
-        if ep_obj_list:
-            return ep_obj_list
-        return False
+        with self.lock:
+            ep_obj_list = []
+            for cur_item in self.queue:
+                if isinstance(cur_item, (ManualSearchQueueItem, FailedQueueItem)) and str(cur_item.show.indexerid) == show:
+                    ep_obj_list.append(cur_item)
+
+            if ep_obj_list:
+                return ep_obj_list
+            return False
     
     def pause_backlog(self):
-        self.min_priority = generic_queue.QueuePriorities.HIGH
+        with self.lock:
+            self.min_priority = generic_queue.QueuePriorities.HIGH
 
     def unpause_backlog(self):
-        self.min_priority = 0
+        with self.lock:
+            self.min_priority = 0
 
     def is_backlog_paused(self):
         # backlog priorities are NORMAL, this should be done properly somewhere
-        return self.min_priority >= generic_queue.QueuePriorities.NORMAL
+        with self.lock:
+            return self.min_priority >= generic_queue.QueuePriorities.NORMAL
+
+    def _is_in_progress(self, itemType):
+        with self.lock:
+            for cur_item in self.queue + [self.currentItem]:
+                if isinstance(cur_item, itemType):
+                    return True
+            return False
 
     def is_manualsearch_in_progress(self):
         # Only referenced in webserve.py, only current running manualsearch or failedsearch is needed!!
-        if isinstance(self.currentItem, (ManualSearchQueueItem, FailedQueueItem)):
-            return True
-        return False
-    
-    def is_backlog_in_progress(self):
-        for cur_item in self.queue + [self.currentItem]:
-            if isinstance(cur_item, BacklogQueueItem):
-                return True
-        return False
+        return self._is_in_progress((ManualSearchQueueItem, FailedQueueItem))
 
-    def is_standard_backlog_in_progress(self):
-        for cur_item in self.queue + [self.currentItem]:
-            if isinstance(cur_item, BacklogQueueItem) and cur_item.standard_backlog:
-                return True
-        return False
+    def is_backlog_in_progress(self):
+        return self._is_in_progress(BacklogQueueItem)
 
     def is_recentsearch_in_progress(self):
-        for cur_item in self.queue + [self.currentItem]:
-            if isinstance(cur_item, RecentSearchQueueItem):
-                return True
-        return False
+        return self._is_in_progress(RecentSearchQueueItem)
+
+    def is_propersearch_in_progress(self):
+        return  self._is_in_progress(ProperSearchQueueItem)
+
+    def is_standard_backlog_in_progress(self):
+        with self.lock:
+            for cur_item in self.queue + [self.currentItem]:
+                if isinstance(cur_item, BacklogQueueItem) and cur_item.standard_backlog:
+                    return True
+            return False
+
+    def type_of_backlog_in_progress(self):
+        limited = full = other = False
+        with self.lock:
+            for cur_item in self.queue + [self.currentItem]:
+                if isinstance(cur_item, BacklogQueueItem):
+                    if cur_item.standard_backlog:
+                        if cur_item.limited_backlog:
+                            limited = True
+                        else:
+                            full = True
+                    else:
+                        other = True
+
+            types = []
+            for msg, variant in ['Limited', limited], ['Full', full], ['On Demand', other]:
+                if variant:
+                    types.append(msg)
+            message = 'None'
+            if types:
+                message = ', '.join(types)
+            return message
 
     def queue_length(self):
-        length = {'backlog': 0, 'recent': 0, 'manual': 0, 'failed': 0}
-        for cur_item in self.queue:
-            if isinstance(cur_item, RecentSearchQueueItem):
-                length['recent'] += 1
-            elif isinstance(cur_item, BacklogQueueItem):
-                length['backlog'] += 1
-            elif isinstance(cur_item, ManualSearchQueueItem):
-                length['manual'] += 1
-            elif isinstance(cur_item, FailedQueueItem):
-                length['failed'] += 1
-        return length
+        length = {'backlog': [], 'recent': 0, 'manual': [], 'failed': [], 'proper': 0}
+        with self.lock:
+            for cur_item in [self.currentItem] + self.queue:
+                if isinstance(cur_item, RecentSearchQueueItem):
+                    length['recent'] += 1
+                elif isinstance(cur_item, BacklogQueueItem):
+                    length['backlog'].append([cur_item.show.indexerid, cur_item.show.name, cur_item.segment, cur_item.standard_backlog, cur_item.limited_backlog, cur_item.forced])
+                elif isinstance(cur_item, ProperSearchQueueItem):
+                    length['proper'] += 1
+                elif isinstance(cur_item, ManualSearchQueueItem):
+                    length['manual'].append([cur_item.show.indexerid, cur_item.show.name, cur_item.segment])
+                elif isinstance(cur_item, FailedQueueItem):
+                    length['failed'].append([cur_item.show.indexerid, cur_item.show.name, cur_item.segment])
+            return length
 
 
     def add_item(self, item):
-        if isinstance(item, RecentSearchQueueItem):
-            # recent searches
+        if isinstance(item, (RecentSearchQueueItem, ProperSearchQueueItem)):
+            # recent and proper searches
             generic_queue.GenericQueue.add_item(self, item)
         elif isinstance(item, BacklogQueueItem) and not self.is_in_queue(item.show, item.segment):
             # backlog searches
@@ -131,7 +167,7 @@ class SearchQueue(generic_queue.GenericQueue):
             # manual and failed searches
             generic_queue.GenericQueue.add_item(self, item)
         else:
-            logger.log(u"Not adding item, it's already in the queue", logger.DEBUG)
+            logger.log(u'Not adding item, it\'s already in the queue', logger.DEBUG)
 
 
 class RecentSearchQueueItem(generic_queue.QueueItem):
@@ -143,49 +179,51 @@ class RecentSearchQueueItem(generic_queue.QueueItem):
     def run(self):
         generic_queue.QueueItem.run(self)
 
-        self._change_missing_episodes()
+        try:
+            self._change_missing_episodes()
 
-        self.update_providers()
+            self.update_providers()
 
-        show_list = sickbeard.showList
-        fromDate = datetime.date.fromordinal(1)
-        for curShow in show_list:
-            if curShow.paused:
-                continue
+            show_list = sickbeard.showList
+            fromDate = datetime.date.fromordinal(1)
+            for curShow in show_list:
+                if curShow.paused:
+                    continue
 
-            self.episodes.extend(wantedEpisodes(curShow, fromDate))
+                self.episodes.extend(wantedEpisodes(curShow, fromDate))
 
-        if not self.episodes:
-            logger.log(u'No search of cache for episodes required')
-            self.success = True
-        else:
-            num_shows = len(set([ep.show.name for ep in self.episodes]))
-            logger.log(u'Found %d needed episode%s spanning %d show%s'
-                       % (len(self.episodes), helpers.maybe_plural(len(self.episodes)),
-                          num_shows, helpers.maybe_plural(num_shows)))
+            if not self.episodes:
+                logger.log(u'No search of cache for episodes required')
+                self.success = True
+            else:
+                num_shows = len(set([ep.show.name for ep in self.episodes]))
+                logger.log(u'Found %d needed episode%s spanning %d show%s'
+                           % (len(self.episodes), helpers.maybe_plural(len(self.episodes)),
+                              num_shows, helpers.maybe_plural(num_shows)))
 
-            try:
-                logger.log(u'Beginning recent search for episodes')
-                found_results = search.searchForNeededEpisodes(self.episodes)
+                try:
+                    logger.log(u'Beginning recent search for episodes')
+                    found_results = search.searchForNeededEpisodes(self.episodes)
 
-                if not len(found_results):
-                    logger.log(u'No needed episodes found')
-                else:
-                    for result in found_results:
-                        # just use the first result for now
-                        logger.log(u'Downloading %s from %s' % (result.name, result.provider.name))
-                        self.success = search.snatchEpisode(result)
+                    if not len(found_results):
+                        logger.log(u'No needed episodes found')
+                    else:
+                        for result in found_results:
+                            # just use the first result for now
+                            logger.log(u'Downloading %s from %s' % (result.name, result.provider.name))
+                            self.success = search.snatchEpisode(result)
 
-                        # give the CPU a break
-                        time.sleep(common.cpu_presets[sickbeard.CPU_PRESET])
+                            # give the CPU a break
+                            time.sleep(common.cpu_presets[sickbeard.CPU_PRESET])
 
-            except Exception:
-                logger.log(traceback.format_exc(), logger.DEBUG)
+                except Exception:
+                    logger.log(traceback.format_exc(), logger.DEBUG)
 
-            if self.success is None:
-                self.success = False
+                if self.success is None:
+                    self.success = False
 
-        self.finish()
+        finally:
+            self.finish()
 
     @staticmethod
     def _change_missing_episodes():
@@ -268,6 +306,21 @@ class RecentSearchQueueItem(generic_queue.QueueItem):
         logger.log('Finished updating provider caches')
 
 
+class ProperSearchQueueItem(generic_queue.QueueItem):
+    def __init__(self):
+        generic_queue.QueueItem.__init__(self, 'Proper Search', PROPER_SEARCH)
+        self.priority = generic_queue.QueuePriorities.HIGH
+        self.success = None
+
+    def run(self):
+        generic_queue.QueueItem.run(self)
+
+        try:
+            properFinder.searchPropers()
+        finally:
+            self.finish()
+
+
 class ManualSearchQueueItem(generic_queue.QueueItem):
     def __init__(self, show, segment):
         generic_queue.QueueItem.__init__(self, 'Manual Search', MANUAL_SEARCH)
@@ -282,14 +335,14 @@ class ManualSearchQueueItem(generic_queue.QueueItem):
         generic_queue.QueueItem.run(self)
 
         try:
-            logger.log("Beginning manual search for: [" + self.segment.prettyName() + "]")
+            logger.log('Beginning manual search for: [' + self.segment.prettyName() + ']')
             self.started = True
             
             searchResult = search.searchProviders(self.show, [self.segment], True)
 
             if searchResult:
                 # just use the first result for now
-                logger.log(u"Downloading " + searchResult[0].name + " from " + searchResult[0].provider.name)
+                logger.log(u'Downloading ' + searchResult[0].name + ' from ' + searchResult[0].provider.name)
                 self.success = search.snatchEpisode(searchResult[0])
 
                 # give the CPU a break
@@ -297,24 +350,25 @@ class ManualSearchQueueItem(generic_queue.QueueItem):
 
             else:
                 ui.notifications.message('No downloads were found',
-                                         "Couldn't find a download for <i>%s</i>" % self.segment.prettyName())
+                                         'Couldn\'t find a download for <i>%s</i>' % self.segment.prettyName())
 
-                logger.log(u"Unable to find a download for: [" + self.segment.prettyName() + "]")
+                logger.log(u'Unable to find a download for: [' + self.segment.prettyName() + ']')
 
         except Exception:
             logger.log(traceback.format_exc(), logger.DEBUG)
         
-        ### Keep a list with the 100 last executed searches
-        fifo(MANUAL_SEARCH_HISTORY, self, MANUAL_SEARCH_HISTORY_SIZE)
-        
-        if self.success is None:
-            self.success = False
+        finally:
+            ### Keep a list with the 100 last executed searches
+            fifo(MANUAL_SEARCH_HISTORY, self, MANUAL_SEARCH_HISTORY_SIZE)
 
-        self.finish()
+            if self.success is None:
+                self.success = False
+
+            self.finish()
 
 
 class BacklogQueueItem(generic_queue.QueueItem):
-    def __init__(self, show, segment, standard_backlog=False):
+    def __init__(self, show, segment, standard_backlog=False, limited_backlog=False, forced=False):
         generic_queue.QueueItem.__init__(self, 'Backlog', BACKLOG_SEARCH)
         self.priority = generic_queue.QueuePriorities.LOW
         self.name = 'BACKLOG-' + str(show.indexerid)
@@ -322,28 +376,31 @@ class BacklogQueueItem(generic_queue.QueueItem):
         self.show = show
         self.segment = segment
         self.standard_backlog = standard_backlog
+        self.limited_backlog = limited_backlog
+        self.forced = forced
 
     def run(self):
         generic_queue.QueueItem.run(self)
 
         try:
-            logger.log("Beginning backlog search for: [" + self.show.name + "]")
+            logger.log('Beginning backlog search for: [' + self.show.name + ']')
             searchResult = search.searchProviders(self.show, self.segment, False)
 
             if searchResult:
                 for result in searchResult:
                     # just use the first result for now
-                    logger.log(u"Downloading " + result.name + " from " + result.provider.name)
+                    logger.log(u'Downloading ' + result.name + ' from ' + result.provider.name)
                     search.snatchEpisode(result)
 
                     # give the CPU a break
                     time.sleep(common.cpu_presets[sickbeard.CPU_PRESET])
             else:
-                logger.log(u"No needed episodes found during backlog search for: [" + self.show.name + "]")
+                logger.log(u'No needed episodes found during backlog search for: [' + self.show.name + ']')
         except Exception:
             logger.log(traceback.format_exc(), logger.DEBUG)
 
-        self.finish()
+        finally:
+            self.finish()
 
 
 class FailedQueueItem(generic_queue.QueueItem):
@@ -363,7 +420,7 @@ class FailedQueueItem(generic_queue.QueueItem):
         try:
             for epObj in self.segment:
             
-                logger.log(u"Marking episode as bad: [" + epObj.prettyName() + "]")
+                logger.log(u'Marking episode as bad: [' + epObj.prettyName() + ']')
                 
                 failed_history.markFailed(epObj)
     
@@ -373,14 +430,14 @@ class FailedQueueItem(generic_queue.QueueItem):
                     history.logFailed(epObj, release, provider)
     
                 failed_history.revertEpisode(epObj)
-                logger.log("Beginning failed download search for: [" + epObj.prettyName() + "]")
+                logger.log('Beginning failed download search for: [' + epObj.prettyName() + ']')
 
             searchResult = search.searchProviders(self.show, self.segment, True)
 
             if searchResult:
                 for result in searchResult:
                     # just use the first result for now
-                    logger.log(u"Downloading " + result.name + " from " + result.provider.name)
+                    logger.log(u'Downloading ' + result.name + ' from ' + result.provider.name)
                     search.snatchEpisode(result)
 
                     # give the CPU a break
@@ -391,13 +448,14 @@ class FailedQueueItem(generic_queue.QueueItem):
         except Exception:
             logger.log(traceback.format_exc(), logger.DEBUG)
             
-        ### Keep a list with the 100 last executed searches
-        fifo(MANUAL_SEARCH_HISTORY, self, MANUAL_SEARCH_HISTORY_SIZE)
+        finally:
+            ### Keep a list with the 100 last executed searches
+            fifo(MANUAL_SEARCH_HISTORY, self, MANUAL_SEARCH_HISTORY_SIZE)
 
-        if self.success is None:
-            self.success = False
+            if self.success is None:
+                self.success = False
 
-        self.finish()
+            self.finish()
         
 def fifo(myList, item, maxSize = 100):
     if len(myList) >= maxSize:

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -31,65 +31,75 @@ from sickbeard import network_timezones
 from sickbeard import failed_history
 
 class ShowUpdater():
+    def __init__(self):
+        self.amActive = False
 
     def run(self, force=False):
 
-        update_datetime = datetime.datetime.now()
-        update_date = update_datetime.date()
+        self.amActive = True
 
-        # refresh network timezones
-        network_timezones.update_network_dict()
+        try:
+            update_datetime = datetime.datetime.now()
+            update_date = update_datetime.date()
 
-        # sure, why not?
-        if sickbeard.USE_FAILED_DOWNLOADS:
-            failed_history.trimHistory()
+            # refresh network timezones
+            network_timezones.update_network_dict()
 
-        # clear the data of unused providers
-        sickbeard.helpers.clear_unused_providers()
+            # sure, why not?
+            if sickbeard.USE_FAILED_DOWNLOADS:
+                failed_history.trimHistory()
 
-        logger.log(u"Doing full update on all shows")
+            # clear the data of unused providers
+            sickbeard.helpers.clear_unused_providers()
 
-        # clean out cache directory, remove everything > 12 hours old
-        sickbeard.helpers.clearCache()
+            logger.log(u'Doing full update on all shows')
 
-        # select 10 'Ended' tv_shows updated more than 90 days ago to include in this update
-        stale_should_update = []
-        stale_update_date = (update_date - datetime.timedelta(days=90)).toordinal()
+            # clean out cache directory, remove everything > 12 hours old
+            sickbeard.helpers.clearCache()
 
-        # last_update_date <= 90 days, sorted ASC because dates are ordinal
-        myDB = db.DBConnection()
-        sql_result = myDB.select(
-            "SELECT indexer_id FROM tv_shows WHERE status = 'Ended' AND last_update_indexer <= ? ORDER BY last_update_indexer ASC LIMIT 10;",
-            [stale_update_date])
+            # select 10 'Ended' tv_shows updated more than 90 days ago and all shows not updated more then 180 days ago to include in this update
+            stale_should_update = []
+            stale_update_date = (update_date - datetime.timedelta(days=90)).toordinal()
+            stale_update_date_max = (update_date - datetime.timedelta(days=180)).toordinal()
 
-        for cur_result in sql_result:
-            stale_should_update.append(int(cur_result['indexer_id']))
+            # last_update_date <= 90 days, sorted ASC because dates are ordinal
+            myDB = db.DBConnection()
+            sql_results = myDB.mass_action([[
+                'SELECT indexer_id FROM tv_shows WHERE last_update_indexer <= ? AND last_update_indexer >= ? ORDER BY last_update_indexer ASC LIMIT 10;',
+                [stale_update_date, stale_update_date_max]], ['SELECT indexer_id FROM tv_shows WHERE last_update_indexer < ?;', [stale_update_date_max]]])
 
-        # start update process
-        piList = []
-        for curShow in sickbeard.showList:
+            for sql_result in sql_results:
+                for cur_result in sql_result:
+                    stale_should_update.append(int(cur_result['indexer_id']))
 
-            try:
-                # get next episode airdate
-                curShow.nextEpisode()
+            # start update process
+            piList = []
+            for curShow in sickbeard.showList:
 
-                # if should_update returns True (not 'Ended') or show is selected stale 'Ended' then update, otherwise just refresh
-                if curShow.should_update(update_date=update_date) or curShow.indexerid in stale_should_update:
-                    curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, True)  # @UndefinedVariable
-                else:
-                    logger.log(
-                        u"Not updating episodes for show " + curShow.name + " because it's marked as ended and last/next episode is not within the grace period.",
-                        logger.DEBUG)
-                    curQueueItem = sickbeard.showQueueScheduler.action.refreshShow(curShow, True)  # @UndefinedVariable
+                try:
+                    # get next episode airdate
+                    curShow.nextEpisode()
 
-                piList.append(curQueueItem)
+                    # if should_update returns True (not 'Ended') or show is selected stale 'Ended' then update, otherwise just refresh
+                    if curShow.should_update(update_date=update_date) or curShow.indexerid in stale_should_update:
+                        curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, scheduled_update=True)  # @UndefinedVariable
+                    else:
+                        logger.log(
+                            u'Not updating episodes for show ' + curShow.name + ' because it\'s marked as ended and last/next episode is not within the grace period.',
+                            logger.DEBUG)
+                        curQueueItem = sickbeard.showQueueScheduler.action.refreshShow(curShow, True, True)  # @UndefinedVariable
 
-            except (exceptions.CantUpdateException, exceptions.CantRefreshException), e:
-                logger.log(u"Automatic update failed: " + ex(e), logger.ERROR)
+                    piList.append(curQueueItem)
 
-        ui.ProgressIndicators.setIndicator('dailyUpdate', ui.QueueProgressIndicator("Daily Update", piList))
+                except (exceptions.CantUpdateException, exceptions.CantRefreshException), e:
+                    logger.log(u'Automatic update failed: ' + ex(e), logger.ERROR)
 
-        logger.log(u"Completed full update on all shows")
+            ui.ProgressIndicators.setIndicator('dailyUpdate', ui.QueueProgressIndicator('Daily Update', piList))
+
+            logger.log(u'Added all shows to show queue for full update')
+
+        finally:
+            self.amActive = False
 
     def __del__(self):
         pass

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -145,7 +145,7 @@ def makeSceneSeasonSearchString(show, ep_obj, extraSearchType=None):
             # for providers that don't allow multiple searches in one request we only search for Sxx style stuff
             else:
                 for cur_season in seasonStrings:
-                    if len(show.release_groups.whitelist) > 0:
+                    if show.is_anime and show.release_groups is not None and show.release_groups.whitelist:
                         for keyword in show.release_groups.whitelist:
                             toReturn.append(keyword + '.' + curShow+ "." + cur_season)
                     else:
@@ -182,7 +182,7 @@ def makeSceneSearchString(show, ep_obj):
 
     for curShow in showNames:
         for curEpString in epStrings:
-            if len(ep_obj.show.release_groups.whitelist) > 0:
+            if ep_obj.show.is_anime and ep_obj.show.release_groups is not None and ep_obj.show.release_groups.whitelist:
                 for keyword in ep_obj.show.release_groups.whitelist:
                     toReturn.append(keyword + '.' + curShow + '.' + curEpString)
             else:

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -83,6 +83,7 @@ class WebServer(threading.Thread):
             (r'%s/home/postprocess(/?.*)' % self.options['web_root'], webserve.HomePostProcess),
             (r'%s/home(/?.*)' % self.options['web_root'], webserve.Home),
             (r'%s/manage/manageSearches(/?.*)' % self.options['web_root'], webserve.ManageSearches),
+            (r'%s/manage/showQueueOverview(/?.*)' % self.options['web_root'], webserve.showQueueOverview),
             (r'%s/manage/(/?.*)' % self.options['web_root'], webserve.Manage),
             (r'%s/ui(/?.*)' % self.options['web_root'], webserve.UI),
             (r'%s/browser(/?.*)' % self.options['web_root'], webserve.WebFileBrowser),


### PR DESCRIPTION
* Add Search Queue Overview page
* Add expandable search queue details on the Manage Searches page
* Fix failed status episodes not included in next_episode search function
* Change prevent another show update from running if one is already running
* Change split Force backlog button on the Manage Searches page into: Force Limited, Force Full
* Change refactor properFinder to be part of the search
* Change improve threading of generic_queue, show_queue and search_queue
* Change disable the Force buttons on the Manage Searches page while a search is running
* Change disable the Pause buttons on the Manage Searches page if a search is not running
* Change staggered periods of testing and updating of all shows "ended" status up to 460 days