### PR TITLE
Fix to correctly load local libraries instead of system installed lib…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 * Fix getManualSearchStatus: object has no attribute 'segment'
 * Change handling of general HTTP error response codes to prevent issues
 * Add handling for CloudFlare custom HTTP response codes
+* Fix to correctly load local libraries instead of system installed libraries
 
 
 ### 0.9.1 (2015-05-25 03:03:00 UTC)

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -47,7 +47,7 @@ except:
     print 'The Python module Cheetah is required'
     sys.exit(1)
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), 'lib')))
 
 # We only need this for compiling an EXE and I will just always do that on 2.6+
 if sys.hexversion >= 0x020600F0:

--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -24,8 +24,8 @@ import os.path
 import sys
 
 sickbeardPath = os.path.split(os.path.split(sys.argv[0])[0])[0]
-sys.path.append(os.path.join(sickbeardPath, 'lib'))
-sys.path.append(sickbeardPath)
+sys.path.insert(1, os.path.join(sickbeardPath, 'lib'))
+sys.path.insert(1, sickbeardPath)
 
 try:
     import requests

--- a/autoProcessTV/mediaToSickbeard.py
+++ b/autoProcessTV/mediaToSickbeard.py
@@ -6,8 +6,8 @@ import ConfigParser
 import logging
 
 sickbeardPath = os.path.split(os.path.split(sys.argv[0])[0])[0]
-sys.path.append(os.path.join(sickbeardPath, 'lib'))
-sys.path.append(sickbeardPath)
+sys.path.insert(1, os.path.join(sickbeardPath, 'lib'))
+sys.path.insert(1, sickbeardPath)
 configFilename = os.path.join(sickbeardPath, 'config.ini')
 
 try:

--- a/lib/tvdb_api/tests/test_tvdb_api.py
+++ b/lib/tvdb_api/tests/test_tvdb_api.py
@@ -17,7 +17,7 @@ import unittest
 # Force parent directory onto path
 #sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-sys.path.append(os.path.abspath('../../tests'))
+sys.path.insert(1, os.path.abspath('../../tests'))
 
 
 import sickbeard

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -32,7 +32,7 @@ import os.path
 import uuid
 import base64
 import sickbeard
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('../lib'))
 from sickbeard import providers, metadata, config, webserveInit
 from sickbeard.providers.generic import GenericProvider
 from providers import btn, newznab, womble, thepiratebay, torrentleech, kat, iptorrents, \

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -2,7 +2,7 @@ import unittest
 
 import sys
 import os.path
-sys.path.append(os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('..'))
 
 from sickbeard import common
 

--- a/tests/helpers_tests.py
+++ b/tests/helpers_tests.py
@@ -5,7 +5,7 @@ import os.path
 from sickbeard import helpers
 
 
-sys.path.append(os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('..'))
 
 
 class HelpersTests(unittest.TestCase):

--- a/tests/migration_tests.py
+++ b/tests/migration_tests.py
@@ -7,8 +7,8 @@ import sickbeard
 from time import sleep
 from sickbeard import db
 
-sys.path.append(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('../lib'))
 
 sickbeard.SYS_ENCODING = 'UTF-8'
 

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -4,8 +4,8 @@ import test_lib as test
 
 import sys, os.path
 
-sys.path.append(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('../lib'))
 
 from sickbeard.name_parser import parser
 

--- a/tests/scene_helpers_tests.py
+++ b/tests/scene_helpers_tests.py
@@ -2,7 +2,7 @@ import unittest
 import test_lib as test
 
 import sys, os.path
-sys.path.append(os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('..'))
 
 from sickbeard import show_name_helpers, scene_exceptions, common, name_cache
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -25,8 +25,8 @@ import glob
 import sys
 import os.path
 
-sys.path.append(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('../lib'))
 
 import sickbeard
 import shutil

--- a/tests/torrent_tests.py
+++ b/tests/torrent_tests.py
@@ -23,8 +23,8 @@ import unittest
 import sys, os.path
 import urlparse
 
-sys.path.append(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('../lib'))
 
 import test_lib as test
 from bs4 import BeautifulSoup

--- a/tests/xem_tests.py
+++ b/tests/xem_tests.py
@@ -24,8 +24,8 @@ import sys, os.path
 import datetime
 import re
 
-sys.path.append(os.path.abspath('..'))
-sys.path.append(os.path.abspath('../lib'))
+sys.path.insert(1, os.path.abspath('..'))
+sys.path.insert(1, os.path.abspath('../lib'))
 
 import test_lib as test
 import sickbeard


### PR DESCRIPTION
…raries

This fix correctly places the local libraries at the start of the sys.path such that they are loaded instead of any libraries that may already exist on the users system. This prevents the issue where a system library that isn't supported by SickGear is loaded and causes errors during operation.