### PR TITLE
Remove useless webproxies from provider TPB as they fail…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 * Fix provider SCC stop snatching releases for episodes already completed
 * Fix provider SCC handle null server responses
 * Change provider SCC remove 1 of 3 requests per search to save 30% time
+* Remove useless webproxies from provider TPB as they fail for one reason or another
+* Change provider TPB to use mediaExtensions from common instead of hard-coded private list
+* Add new tld variants to provider TPB
+* Add test for authenticity to provider TPB to notify of 3rd party block
 * Change provider Womble's use SSL
 * Change refactor and code simplification for torrent providers
 * Add Rarbg torrent provider


### PR DESCRIPTION
…SSL and have other issues. These were a terrible inclusion to fool users into a false sense of security and have no place here. Instead, a proper sustainable solution can and should be used.

Change provider TPB to use mediaExtensions from common instead of hard-coded private list.
Add new tld variants to provider TPB.
Add test for authenticity to provider TPB to notify of 3rd party block.