### PR TITLE
Fix edit on show page for shows that have anime enabled in mass edit.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,9 @@
 * Change to make pushbullet error messages clearer
 * Change pyNMA use of urllib to requests (ref:hacks.txt)
 * Change Trakt url to fix baseline uses (e.g. add from trending)
+* Fix edit on show page for shows that have anime enabled in mass edit
+* Change to only show option "End upgrade on first match" on edit show page if quality custom is selected
+* Change label "Show is grouped in" in edit show page to "Show is in group" and move the section higher
 
 [develop changelog]
 * Update Requests library 2.7.0 (ab1f493) to 2.7.0 (8b5e457)

--- a/gui/slick/interfaces/default/editShow.tmpl
+++ b/gui/slick/interfaces/default/editShow.tmpl
@@ -82,7 +82,7 @@
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_qualityChooser.tmpl')
 
 #if $anyQualities + $bestQualities
-			<div class="field-pair">
+			<div class="field-pair show-if-quality-custom">
 				<label for="archive_firstmatch">
 					<span class="component-title">End upgrade on first match</span>
 					<span class="component-desc">
@@ -211,6 +211,20 @@
 			</label>
 		</div>
 
+		<div class="field-pair#if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then ' hidden' else ''#" style="margin-bottom:10px">
+			<label for="tag">
+				<span class="component-title">Show is in group</span>
+				<span class="component-desc">
+					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
+#for $tag in $sickbeard.SHOW_TAGS:
+						<option value="$tag" #if $tag == $show.tag then 'selected="selected"' else ''#>$tag#echo ('', ' (default)')['Show List' == $tag]#</option>
+#end for
+					</select>
+					<span>and is displayed on the show list page under this section</span>
+				</span>
+			</label>
+		</div>
+
 		<div class="field-pair">
 			<label for="sports">
 				<span class="component-title">Show is sports</span>
@@ -227,20 +241,6 @@
 				<span class="component-desc">
 					<input type="checkbox" name="anime" id="anime"#if $show.is_anime then $html_checked else ''#>
 					<p>enable if this show is anime and episode releases are named ... <em class="grey-text">Show.265</em> instead of <em class="grey-text">Show.S02E03</em></p>
-				</span>
-			</label>
-		</div>
-
-		<div class="field-pair#if $sickbeard.SHOWLIST_TAGVIEW != 'custom' then ' hidden' else ''#" style="margin-bottom:10px">
-			<label for="tag">
-				<span class="component-title">Show is grouped in</span>
-				<span class="component-desc">
-					<select name="tag" id="tag" class="form-control form-control-inline input-sm">
-#for $tag in $sickbeard.SHOW_TAGS:
-						<option value="$tag" #if $tag == $show.tag then 'selected="selected"' else ''#>$tag#echo ('', ' (default)')['Show List' == $tag]#</option>
-#end for
-					</select>
-					<span>and displays on the show list page under this section</span>
 				</span>
 			</label>
 		</div>

--- a/gui/slick/interfaces/default/inc_qualityChooser.tmpl
+++ b/gui/slick/interfaces/default/inc_qualityChooser.tmpl
@@ -19,7 +19,7 @@
 </div>
 
 <div id="customQualityWrapper">
-	<div id="customQuality">
+	<div id="customQuality" class="show-if-quality-custom">
 		<div class="component-group-desc">
 			<p>An <em>Initial</em> quality episode must be found before an <em>Upgrade to</em> selection is considered.</p>
 		</div>

--- a/gui/slick/js/qualityChooser.js
+++ b/gui/slick/js/qualityChooser.js
@@ -1,5 +1,5 @@
 function setFromPresets (preset) {
-	var elCustomQuality = $('#customQuality'),
+	var elCustomQuality = $('.show-if-quality-custom'),
 		selected = 'selected';
 	if (0 == preset) {
 		elCustomQuality.show();

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1247,6 +1247,8 @@ class Home(MainHandler):
             t.submenu = self.HomeMenu()
 
             if showObj.is_anime:
+                if not showObj.release_groups:
+                    showObj.release_groups = BlackAndWhiteList(showObj.indexerid)
                 t.whitelist = showObj.release_groups.whitelist
                 t.blacklist = showObj.release_groups.blacklist
 


### PR DESCRIPTION
* Change to only show option "End upgrade on first match" on edit show page if quality custom is selected.
* Change label "Show is grouped in" in edit show page to "Show is in group" and move the section higher.