### PR TITLE
Fix post processing of anime with version tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,6 +105,7 @@
 * Fix issue parsing items in ToktoToshokan provider
 * Change to only show option "End upgrade on first match" on edit show page if quality custom is selected
 * Change label "Show is grouped in" in edit show page to "Show is in group" and move the section higher
+* Fix post processing of anime with version tags
 
 [develop changelog]
 * Update Requests library 2.7.0 (ab1f493) to 2.7.0 (8b5e457)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -882,7 +882,7 @@ class PostProcessor(object):
             ep_obj.show.writeMetadata(True)
 
         # if we're processing an episode of type anime, get the anime version
-        anime_version = (-1, self.anime_version)[ep_obj.show.is_anime and None is not self.anime_version and self.anime_version]
+        anime_version = (-1, self.anime_version)[ep_obj.show.is_anime and None is not self.anime_version]
 
         # update the ep info before we rename so the quality & release name go into the name properly
         sql_l = []


### PR DESCRIPTION
Fixes this:

`<br/>  File "/home/adam/sickgear/sickbeard/postProcessor.py", line 885, in process
anime_version = (-1, self.anime_version)[ep_obj.show.is_anime and None is not self.anime_version and self.anime_version]
<br/>IndexError: tuple index out of range
<br/></p>`

[ep_obj.show.is_anime and None is not self.anime_version and self.anime_version] will return self.anime_version if it exists! It doesn't return True/1