### PR TITLE
Change Nameparser not to query online sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 * Update change to suppress reporting of Tornado exception error 1 to updated package (ref:hacks.txt)
 * Update fix for API response header for JSON content type and the return of JSONP data to updated package (ref:hacks.txt)
 * Fix post processing season pack folders
+* Change Nameparser to be fully offline
 
 
 ### 0.10.0 (2015-08-06 11:05:00 UTC)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -854,7 +854,7 @@ def full_sanitizeSceneName(name):
     return re.sub('[. -]', ' ', sanitizeSceneName(name)).lower().lstrip()
 
 
-def get_show(name, try_indexers=False, try_scene_exceptions=False):
+def get_show(name, try_scene_exceptions=False):
     if not sickbeard.showList or None is name:
         return
 
@@ -871,10 +871,6 @@ def get_show(name, try_indexers=False, try_scene_exceptions=False):
             indexer_id = sickbeard.scene_exceptions.get_scene_exception_by_name(name)[0]
             if indexer_id:
                 show_obj = findCertainShow(sickbeard.showList, indexer_id)
-
-        if not show_obj and try_indexers:
-            show_obj = findCertainShow(sickbeard.showList,
-                                       searchIndexerForShowID(full_sanitizeSceneName(name), ui=classes.ShowListUI)[2])
 
         # add show to cache
         if show_obj and not from_cache:

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -36,12 +36,11 @@ class NameParser(object):
     NORMAL_REGEX = 1
     ANIME_REGEX = 2
 
-    def __init__(self, file_name=True, showObj=None, try_indexers=False, try_scene_exceptions=False, convert=False,
+    def __init__(self, file_name=True, showObj=None, try_scene_exceptions=False, convert=False,
                  naming_pattern=False, testing=False):
 
         self.file_name = file_name
         self.showObj = showObj
-        self.try_indexers = try_indexers
         self.try_scene_exceptions = try_scene_exceptions
         self.convert = convert
         self.naming_pattern = naming_pattern
@@ -203,7 +202,7 @@ class NameParser(object):
                 show = None
                 if not self.naming_pattern:
                     # try and create a show object for this result
-                    show = helpers.get_show(best_result.series_name, self.try_indexers, self.try_scene_exceptions)
+                    show = helpers.get_show(best_result.series_name, self.try_scene_exceptions)
 
                 # confirm passed in show object indexer id matches result show object indexer id
                 if show and not self.testing:

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -470,8 +470,9 @@ class PostProcessor(object):
         name = helpers.remove_non_release_groups(helpers.remove_extension(name))
 
         # parse the name to break it into show name, season, and episode
-        np = NameParser(resource, try_indexers=True, try_scene_exceptions=True, convert=True)
-        parse_result = np.parse(name)
+        parse_result = NameParser(resource,
+                                  try_scene_exceptions=True,
+                                  convert=True).parse(name)
         self._log(u'Parsed %s<br />.. into %s' % (name, str(parse_result).decode('utf-8', 'xmlcharrefreplace')), logger.DEBUG)
 
         if parse_result.is_air_by_date:
@@ -983,7 +984,7 @@ class PostProcessor(object):
                 raise exceptions.PostProcessingFailed(u'Unable to move the files to the new location')
         except (OSError, IOError):
             raise exceptions.PostProcessingFailed(u'Unable to move the files to the new location')
-                
+
         # download subtitles
         dosubs = sickbeard.USE_SUBTITLES and ep_obj.show.subtitles
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -421,8 +421,7 @@ class ProcessTVShow(object):
 
         parse_result = None
         try:
-            parse_result = NameParser(try_indexers=True,
-                                      try_scene_exceptions=True,
+            parse_result = NameParser(try_scene_exceptions=True,
                                       convert=True).parse(videofile,
                                                           cache_result=False)
         except (InvalidNameException, InvalidShowException):
@@ -430,8 +429,7 @@ class ProcessTVShow(object):
             pass
         if None is parse_result:
             try:
-                parse_result = NameParser(try_indexers=True,
-                                          try_scene_exceptions=True,
+                parse_result = NameParser(try_scene_exceptions=True,
                                           convert=True).parse(
                                               dir_name, cache_result=False)
             except (InvalidNameException, InvalidShowException):

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -427,8 +427,8 @@ class TVShow(object):
 
             try:
                 parse_result = None
-                np = NameParser(False, showObj=self, try_indexers=True)
-                parse_result = np.parse(ep_file_name)
+                parse_result = NameParser(False,
+                                          showObj=self).parse(ep_file_name)
             except (InvalidNameException, InvalidShowException):
                 pass
 
@@ -619,8 +619,7 @@ class TVShow(object):
         logger.log(u'%s: Creating episode object from %s' % (self.indexerid, file), logger.DEBUG)
 
         try:
-            my_parser = NameParser(showObj=self, try_indexers=True)
-            parse_result = my_parser.parse(file)
+            parse_result = NameParser(showObj=self).parse(file)
         except InvalidNameException:
             logger.log(u'Unable to parse the filename %s into a valid episode' % file, logger.DEBUG)
             return None


### PR DESCRIPTION
Nameparser has a parameter try_indexers, which tells Nameparser
to go online while parsing the filename for a show.

Since we have all the information for the shows we want to handle
in our database, there is no need to query indexers for the
information.

This change also reduces abuse of the indexers, since SG no longer
queries indexers whenever an unknown file is postprocessed.
