### PR TITLE
Change default de-referrer url to blank

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -60,7 +60,7 @@ CFG = None
 CONFIG_FILE = None
 
 # This is the version of the config we EXPECT to find
-CONFIG_VERSION = 12
+CONFIG_VERSION = 13
 
 # Default encryption version (0 for None)
 ENCRYPTION_VERSION = 0
@@ -641,7 +641,7 @@ def initialize(consoleLogging=True):
 
         CPU_PRESET = check_setting_str(CFG, 'General', 'cpu_preset', 'NORMAL')
 
-        ANON_REDIRECT = check_setting_str(CFG, 'General', 'anon_redirect', 'http://dereferer.org/?')
+        ANON_REDIRECT = check_setting_str(CFG, 'General', 'anon_redirect', '')
         PROXY_SETTING = check_setting_str(CFG, 'General', 'proxy_setting', '')
         PROXY_INDEXERS = bool(check_setting_int(CFG, 'General', 'proxy_indexers', 1))
         # attempt to help prevent users from breaking links by using a bad url

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -444,7 +444,8 @@ class ConfigMigrator():
                                 9: 'Rename pushbullet variables',
                                 10: 'Reset backlog frequency to default',
                                 11: 'Migrate anime split view to new layout',
-                                12: 'Add "hevc" and some non-english languages to ignore words if not found'}
+                                12: 'Add "hevc" and some non-english languages to ignore words if not found',
+                                13: 'Change default dereferrer url to blank'}
 
     def migrate_config(self):
         """ Calls each successive migration until the config is the same version as SG expects """
@@ -768,3 +769,8 @@ class ConfigMigrator():
                 new_list += [new_word]
 
         sickbeard.IGNORE_WORDS = ', '.join(sorted(new_list))
+
+    def _migrate_v13(self):
+        # change dereferrer.org urls to blank, but leave any other url untouched
+        if sickbeard.ANON_REDIRECT == 'http://dereferer.org/?':
+            sickbeard.ANON_REDIRECT = ''


### PR DESCRIPTION
dereferrer.org is no longer active, so we will clear the config entry from users settings so external links will work.