### PR TITLE
Change adding show processing to be highest priority.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
 * Add scene qualities WEB.h264 to SDTV, 720p.WEB.h264 to WEB DL 720p, and 1080p.WEB.h264 to WEB DL 1080p
 * Change improve handling when provider PiSexy is missing expected data
 * Change show list second level sort criteria
+* Change adding show processing to be highest priority
+* Use timezones to check unaired status during show update/adding
 
 
 ### 0.11.10 (2016-03-17 19:00:00 UTC)

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -403,6 +403,8 @@
 		</h3>
 	</div>
 #else:
+#set $network_timezone = $network_timezones.get_network_timezone($show.network)
+#set $network_time = $network_timezones.parse_time($show.airs)
 #for $epResult in $sqlResults
     #set $epStr = '%sx%s' % ($epResult['season'], $epResult['episode'])
     #if not $epStr in $epCats or (0 == int($epResult['season']) and not $sickbeard.DISPLAY_SHOW_SPECIALS)
@@ -526,7 +528,7 @@
 		</td>
 
 		<td class="col-airdate">
-			<span class="${fuzzydate}">#if 1 == int($epResult['airdate']) then 'never' else $sbdatetime.sbdatetime.sbfdate($sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($epResult['airdate'], $show.airs, $show.network)))#</span>
+			<span class="${fuzzydate}">#if 1 == int($epResult['airdate']) then 'never' else $sbdatetime.sbdatetime.sbfdate($sbdatetime.sbdatetime.convert_to_setting($network_timezones.parse_date_time($epResult['airdate'], $network_time, $network_timezone)))#</span>
 		</td>
 
     #if $sickbeard.USE_SUBTITLES and $show.subtitles

--- a/sickbeard/generic_queue.py
+++ b/sickbeard/generic_queue.py
@@ -26,6 +26,7 @@ class QueuePriorities:
     LOW = 10
     NORMAL = 20
     HIGH = 30
+    VERYHIGH = 40
 
 
 class GenericQueue(object):

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -250,6 +250,8 @@ class QueueItemAdd(ShowQueueItem):
         # this will initialize self.show to None
         ShowQueueItem.__init__(self, ShowQueueActions.ADD, self.show, scheduled_update)
 
+        self.priority = generic_queue.QueuePriorities.VERYHIGH
+
     def _getName(self):
         """
         Returns the show name if there is a show object created, if not returns


### PR DESCRIPTION
Use timezones to check unaired status during show update/adding.
Allow parse_date_time to accept timezone objects and parsed time tuples.
Add country code fallback for network name (timezone).