### PR TITLE
Change storing metadata nfo vars from int to strings to resolve lxml …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,7 @@
 * Change adding show processing to be highest priority
 * Use timezones to check unaired status during show update/adding
 * Fix syntax error causing renamer to error out
+* Change storing metadata nfo vars from int to strings to resolve lxml type exceptions that don't occur with etree
 
 
 ### 0.11.11 (2016-04-05 19:20:00 UTC)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -21,7 +21,7 @@ from __future__ import with_statement
 import os.path
 
 try:
-  from lxml import etree
+    from lxml import etree
 except ImportError:
     try:
         import xml.etree.cElementTree as etree
@@ -32,7 +32,7 @@ import re
 
 import sickbeard
 
-from sickbeard import exceptions, helpers
+from sickbeard import helpers
 from sickbeard.metadata import helpers as metadata_helpers
 from sickbeard import logger
 from sickbeard import encodingKludge as ek
@@ -282,40 +282,40 @@ class GenericMetadata():
 
     def update_show_indexer_metadata(self, show_obj):
         if self.show_metadata and show_obj and self._has_show_metadata(show_obj):
-            logger.log(
-                u"Metadata provider " + self.name + " updating show indexer info metadata file for " + show_obj.name,
-                logger.DEBUG)
+            logger.log(u'Metadata provider %s updating show indexer metadata file for %s' % (self.name, show_obj.name),
+                       logger.DEBUG)
 
             nfo_file_path = self.get_show_file_path(show_obj)
             try:
                 with ek.ek(open, nfo_file_path, 'r') as xmlFileObj:
-                    showXML = etree.ElementTree(file=xmlFileObj)
+                    show_xml = etree.ElementTree(file=xmlFileObj)
 
-                indexer = showXML.find('indexer')
-                indexerid = showXML.find('id')
+                indexer = show_xml.find('indexer')
+                indexerid = show_xml.find('id')
 
-                root = showXML.getroot()
+                root = show_xml.getroot()
+                show_indexer = str(show_obj.indexer)
                 if None is not indexer:
-                    indexer.text = show_obj.indexer
+                    indexer.text = show_indexer
                 else:
-                    etree.SubElement(root, "indexer").text = str(show_obj.indexer)
+                    etree.SubElement(root, 'indexer').text = show_indexer
 
+                show_indexerid = str(show_obj.indexerid)
                 if None is not indexerid:
-                    indexerid.text = show_obj.indexerid
+                    indexerid.text = show_indexerid
                 else:
-                    etree.SubElement(root, "id").text = str(show_obj.indexerid)
+                    etree.SubElement(root, 'id').text = show_indexerid
 
                 # Make it purdy
                 helpers.indentXML(root)
 
-                showXML.write(nfo_file_path)
+                show_xml.write(nfo_file_path)
                 helpers.chmodAsParent(nfo_file_path)
 
                 return True
             except IOError as e:
-                logger.log(
-                    u"Unable to write file to " + nfo_file_path + " - are you sure the folder is writable? " + ex(e),
-                    logger.ERROR)
+                logger.log(u'Unable to write file %s - is the folder writable? %s' % (nfo_file_path, ex(e)),
+                           logger.ERROR)
 
     def create_fanart(self, show_obj):
         if self.fanart and show_obj and not self._has_fanart(show_obj):


### PR DESCRIPTION
…type exceptions that don't occur with etree.