### PR TITLE
Add CPU Quota for SickGear

### DIFF
--- a/init-scripts/init.systemd
+++ b/init-scripts/init.systemd
@@ -53,5 +53,8 @@ Type=forking
 GuessMainPID=no
 ExecStart=/usr/bin/python /opt/sickgear/SickBeard.py -q --daemon --nolaunch --datadir=/opt/sickgear
 
+CPUAccounting=true
+CPUQuota=50%
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I have had a lot of issues with SickGear eating up every resource that I give to it. Most people are not going to be running SickGear on it's own dedicated hardware. While you can do a lot of resource management with virtualization, even then, I would imagine you're stacking other services with this. At one point, I was setting SickGear to restart nightly to keep the process from completely locking up my system. However, systemd has given us some pretty neat resources to handle this sort of stuff.

I'm proposing we set a 50% CPU quota on SickGear, as it helps keep resources freed for other processes. If the user wants to dedicate all resources, then they have the option of changing the service file. However, this sets a pretty good precedent for resource allocation.

For now, I'm only setting a CPU quota, however, there are FAR MORE options in case we want to further manage the resources which SickGear can use. https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html