### PR TITLE
Change instantly use saved value from Search Settings/Episode Search/…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,7 @@
 * Add enable, disable and delete public IMDb watchlists to Config/General/Interface with a default 'SickGear' list
 * Change prevent duplicate show ids from presenting items on 'Add from... Browse Shows'
 * Change add 'nocache' kwarg to helpers.getURL to facilitate non-cached requests
+* Change instantly use saved value from Search Settings/Episode Search/"Check propers every" instead of after a restart
 
 
 ### 0.11.11 (2016-04-05 19:20:00 UTC)

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -58,10 +58,8 @@
 									<span class="component-title">Check propers every:</span>
 									<span class="component-desc">
 										<select id="check_propers_interval" name="check_propers_interval" class="form-control input-sm">
-#set $check_propers_interval_text = {'daily': "24 hours", '4h': "4 hours", '90m': "90 mins", '45m': "45 mins", '15m': "15 mins"}
-#for $curInterval in ('daily', '4h', '90m', '45m', '15m'):
-    #set $selected = $html_selected if $sickbeard.CHECK_PROPERS_INTERVAL == $curInterval else ''
-											<option value="$curInterval"$selected>$check_propers_interval_text[$curInterval]</option>
+#for $curKey, $curText, $void in $propers_intervals:
+											<option value="$curKey"#echo ('', $html_selected)[$sickbeard.CHECK_PROPERS_INTERVAL == $curKey]#>$curText</option>
 #end for
 										</select>
 									</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1172,15 +1172,16 @@ def initialize(consoleLogging=True):
                                                                        else datetime.timedelta(minutes=10),
                                                                        prevent_cycle_run=searchQueueScheduler.action.is_standard_backlog_in_progress)
 
-        search_intervals = {'15m': 15, '45m': 45, '90m': 90, '4h': 4 * 60, 'daily': 24 * 60}
-        if CHECK_PROPERS_INTERVAL in search_intervals:
-            update_interval = datetime.timedelta(minutes=search_intervals[CHECK_PROPERS_INTERVAL])
+        propers_searcher = search_propers.ProperSearcher()
+        item = [(k, n, v) for (k, n, v) in propers_searcher.search_intervals if k == CHECK_PROPERS_INTERVAL]
+        if item:
+            update_interval = datetime.timedelta(minutes=item[0][2])
             run_at = None
         else:
             update_interval = datetime.timedelta(hours=1)
             run_at = datetime.time(hour=1)  # 1 AM
 
-        properFinderScheduler = scheduler.Scheduler(search_propers.ProperSearcher(),
+        properFinderScheduler = scheduler.Scheduler(propers_searcher,
                                                     cycleTime=update_interval,
                                                     threadName='FINDPROPERS',
                                                     start_time=run_at,

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -58,12 +58,16 @@ def search_propers():
     _set_last_proper_search(datetime.datetime.today().toordinal())
 
     run_at = ''
-    if None is sickbeard.properFinderScheduler.start_time:
-        run_in = sickbeard.properFinderScheduler.lastRun + sickbeard.properFinderScheduler.cycleTime - datetime.datetime.now()
-        hours, remainder = divmod(run_in.seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-        run_at = u', next check in approx. ' + (
-            '%dh, %dm' % (hours, minutes) if 0 < hours else '%dm, %ds' % (minutes, seconds))
+    proper_sch = sickbeard.properFinderScheduler
+    if None is proper_sch.start_time:
+        run_in = proper_sch.lastRun + proper_sch.cycleTime - datetime.datetime.now()
+        run_at = u', next check '
+        if datetime.timedelta() > run_in:
+            run_at += u'imminent'
+        else:
+            hours, remainder = divmod(run_in.seconds, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            run_at += u'in approx. ' + ('%dh, %dm' % (hours, minutes) if 0 < hours else '%dm, %ds' % (minutes, seconds))
 
     logger.log(u'Completed the search for new propers%s' % run_at)
 

--- a/sickbeard/search_propers.py
+++ b/sickbeard/search_propers.py
@@ -26,6 +26,8 @@ class ProperSearcher:
     def __init__(self):
         self.lock = threading.Lock()
         self.amActive = False
+        self.search_intervals = [('daily', '24 hours', 24 * 60), ('4h', '4 hours', 4 * 60),
+                                 ('90m', '90 mins', 90), ('45m', '45 mins', 45), ('15m', '15 mins', 15)]
 
     def run(self):
 


### PR DESCRIPTION
…"Check propers every" instead of after a restart.

Change centralise interval keys, texts, and values into the ProperSearcher class.