### PR TITLE
Add if all torrent caches fail, save magnets as files...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,6 +185,8 @@
 * Change fuzzyMoment to handle air dates before ~1970 on display show page
 * Change limit availability of fuzzy date functions on General Config/Interface to English locale systems
 * Add Plex notifications secure connect where available (PMS 1.1.4.2757 and newer with username and password)
+* Add if all torrent caches fail, save magnets from RARBG and TPB as files for clients (or plugins) that now support it
+* Add advice to logs if all caches fail to switch to direct client connect instead of the basic blackhole method
 
 [develop changelog]
 * Change send nzb data to NZBGet for Anizb instead of url

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -230,8 +230,22 @@ class GenericProvider:
             else:
                 del(self.session.headers['Referer'])
 
-        if not saved:
+        if not saved and 'magnet' == link_type:
             logger.log(u'All torrent cache servers failed to return a downloadable result', logger.ERROR)
+            logger.log(u'Advice: in search settings, change from method blackhole to direct torrent client connect',
+                       logger.ERROR)
+            final_file = ek.ek(os.path.join, final_dir, '%s.%s' % (helpers.sanitizeFileName(result.name), link_type))
+            try:
+                with open(final_file, 'wb') as fp:
+                    fp.write(result.url)
+                    fp.flush()
+                    os.fsync(fp.fileno())
+                logger.log(u'Saved magnet link to file as some clients (or plugins) support this, %s' % final_file)
+
+            except (StandardError, Exception):
+                pass
+        elif not saved:
+            logger.log(u'Server failed to return anything useful', logger.ERROR)
 
         return saved
 


### PR DESCRIPTION
…for clients (or plugins) that now support it.

Add advice to logs if all caches fail to switch to direct client connect instead of the basic blackhole method.