### PR TITLE
Add option to limit WebDL propers to original release group...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 * Add detection of '1080p Remux' releases as fullhdbluray
 * Add "Perform search tasks" to Config/Media Providers/Options
 * Change improve clarity of enabled providers on Config/Media Providers
+* Add option to limit WebDL propers to original release group under Config/Search/Media Search
 * Change add IPv4 config option when enabling IPv6.
 
 

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -58,6 +58,15 @@
 						</div>
 						<div id="content_download_propers">
 							<div class="field-pair">
+								<label>
+									<span class="component-title">Limit WebDL propers</span>
+									<span class="component-desc">
+										<input type="checkbox" name="propers_webdl_onegrp"#echo ('', $html_checked)[$sickbeard.PROPERS_WEBDL_ONEGRP]#>
+										<p>Only allow WebDL 'Propers' from the original release group</p>
+									</span>
+								</label>
+							</div>
+							<div class="field-pair">
 								<label for="check_propers_interval">
 									<span class="component-title">Check propers every:</span>
 									<span class="component-desc">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -200,6 +200,7 @@ TORRENT_METHOD = None
 TORRENT_DIR = None
 DOWNLOAD_PROPERS = False
 CHECK_PROPERS_INTERVAL = None
+PROPERS_WEBDL_ONEGRP = True
 ALLOW_HIGH_PRIORITY = False
 NEWZNAB_DATA = ''
 
@@ -551,7 +552,7 @@ def initialize(console_logging=True):
         global BRANCH, CUR_COMMIT_BRANCH, GIT_REMOTE, CUR_COMMIT_HASH, GIT_PATH, CPU_PRESET, ANON_REDIRECT, \
             ENCRYPTION_VERSION, PROXY_SETTING, PROXY_INDEXERS, FILE_LOGGING_PRESET
         # Search Settings/Episode
-        global DOWNLOAD_PROPERS, CHECK_PROPERS_INTERVAL, RECENTSEARCH_FREQUENCY, \
+        global DOWNLOAD_PROPERS, PROPERS_WEBDL_ONEGRP, CHECK_PROPERS_INTERVAL, RECENTSEARCH_FREQUENCY, \
             BACKLOG_DAYS, BACKLOG_NOFULL, BACKLOG_FREQUENCY, USENET_RETENTION, IGNORE_WORDS, REQUIRE_WORDS, \
             ALLOW_HIGH_PRIORITY, SEARCH_UNAIRED, UNAIRED_RECENT_SEARCH_ONLY
         # Search Settings/NZB search
@@ -788,6 +789,7 @@ def initialize(console_logging=True):
             TORRENT_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        PROPERS_WEBDL_ONEGRP = bool(check_setting_int(CFG, 'General', 'propers_webdl_onegrp', 1))
         CHECK_PROPERS_INTERVAL = check_setting_str(CFG, 'General', 'check_propers_interval', '')
         if CHECK_PROPERS_INTERVAL not in ('15m', '45m', '90m', '4h', 'daily'):
             CHECK_PROPERS_INTERVAL = 'daily'
@@ -1469,6 +1471,7 @@ def save_config():
     new_config['General']['backlog_frequency'] = int(BACKLOG_FREQUENCY)
     new_config['General']['update_frequency'] = int(UPDATE_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['propers_webdl_onegrp'] = int(PROPERS_WEBDL_ONEGRP)
     new_config['General']['check_propers_interval'] = CHECK_PROPERS_INTERVAL
     new_config['General']['allow_high_priority'] = int(ALLOW_HIGH_PRIORITY)
     new_config['General']['recentsearch_startup'] = int(RECENTSEARCH_STARTUP)

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -177,6 +177,11 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
                 or cur_proper.quality != old_quality:
             continue
 
+        # only take same release qroup for web dl's
+        if old_quality in (Quality.HDWEBDL, Quality.FULLHDWEBDL, Quality.UHD4KWEB) and \
+                cur_proper.release_group != sql_results[0]['release_group']:
+            continue
+
         # check if we actually want this proper (if it's the right release group and a higher version)
         if parse_result.is_anime:
             my_db = db.DBConnection()

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -87,7 +87,8 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
         logger.log(u'Searching for new PROPER releases')
 
         try:
-            found_propers = cur_provider.find_propers(search_date=aired_since_shows, shows=recent_shows, anime=recent_anime)
+            found_propers = cur_provider.find_propers(search_date=aired_since_shows, shows=recent_shows,
+                                                      anime=recent_anime)
         except exceptions.AuthException as e:
             logger.log(u'Authentication error: ' + ex(e), logger.ERROR)
             continue
@@ -115,7 +116,7 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
                         count += 1
                 except (InvalidNameException, InvalidShowException):
                     continue
-                except Exception:
+                except (StandardError, Exception):
                     continue
 
         cur_provider.log_result('Propers', count, '%s' % cur_provider.name)
@@ -166,8 +167,9 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
 
         # check if we actually want this proper (if it's the right quality)
         my_db = db.DBConnection()
-        sql_results = my_db.select('SELECT status FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
-                                   [cur_proper.indexerid, cur_proper.season, cur_proper.episode])
+        sql_results = my_db.select(
+            'SELECT release_group, status, version FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
+            [cur_proper.indexerid, cur_proper.season, cur_proper.episode])
         if not sql_results:
             continue
 
@@ -177,29 +179,28 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
                 or cur_proper.quality != old_quality:
             continue
 
-        # only take same release qroup for web dl's
-        if old_quality in (Quality.HDWEBDL, Quality.FULLHDWEBDL, Quality.UHD4KWEB) and \
-                cur_proper.release_group != sql_results[0]['release_group']:
+        old_release_group = sql_results[0]['release_group']
+        log_same_grp = 'Skipping proper from release group: [%s], does not match existing release group: [%s] for [%s]'\
+                       % (cur_proper.release_group, old_release_group, cur_proper.name)
+
+        # for webldls, prevent propers from different groups
+        if sickbeard.PROPERS_WEBDL_ONEGRP and \
+                old_quality in (Quality.HDWEBDL, Quality.FULLHDWEBDL, Quality.UHD4KWEB) and \
+                cur_proper.release_group != old_release_group:
+            logger.log(log_same_grp, logger.DEBUG)
             continue
 
         # check if we actually want this proper (if it's the right release group and a higher version)
         if parse_result.is_anime:
-            my_db = db.DBConnection()
-            sql_results = my_db.select(
-                'SELECT release_group, version FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
-                [cur_proper.indexerid, cur_proper.season, cur_proper.episode])
 
             old_version = int(sql_results[0]['version'])
-            old_release_group = (sql_results[0]['release_group'])
-
             if -1 < old_version < cur_proper.version:
                 logger.log(u'Found new anime v%s to replace existing v%s' % (cur_proper.version, old_version))
             else:
                 continue
 
             if cur_proper.release_group != old_release_group:
-                logger.log(u'Skipping proper from release group: %s, does not match existing release group: %s' %
-                           (cur_proper.release_group, old_release_group))
+                logger.log(log_same_grp, logger.DEBUG)
                 continue
 
         # if the show is in our list and there hasn't been a proper already added for that particular episode
@@ -318,7 +319,7 @@ def _get_last_proper_search():
 
     try:
         last_proper_search = datetime.date.fromordinal(int(sql_results[0]['last_proper_search']))
-    except:
+    except (StandardError, Exception):
         return datetime.date.fromordinal(1)
 
     return last_proper_search

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4793,11 +4793,12 @@ class ConfigSearch(Config):
                    nzbget_category=None, nzbget_priority=None, nzbget_host=None, nzbget_use_https=None,
                    backlog_days=None, backlog_frequency=None, search_unaired=None, unaired_recent_search_only=None,
                    recentsearch_frequency=None, nzb_method=None, torrent_method=None, usenet_retention=None,
-                   download_propers=None, check_propers_interval=None, allow_high_priority=None,
+                   download_propers=None, propers_webdl_onegrp=None, check_propers_interval=None,
+                   allow_high_priority=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_path=None, torrent_verify_cert=None,
-                   torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None, ignore_words=None, require_words=None,
-                   backlog_nofull=None):
+                   torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None,
+                   ignore_words=None, require_words=None, backlog_nofull=None):
 
         results = []
 
@@ -4830,6 +4831,7 @@ class ConfigSearch(Config):
         sickbeard.REQUIRE_WORDS = require_words if require_words else ''
 
         sickbeard.DOWNLOAD_PROPERS = config.checkbox_to_value(download_propers)
+        sickbeard.PROPERS_WEBDL_ONEGRP = config.checkbox_to_value(propers_webdl_onegrp)
         if sickbeard.CHECK_PROPERS_INTERVAL != check_propers_interval:
             sickbeard.CHECK_PROPERS_INTERVAL = check_propers_interval
 


### PR DESCRIPTION
Add option to limit WebDL propers to original release group under Config/Search/Media Search.

Background: Identical episodes can originate from multiple WEBDL sources, e.g. NF, AMZN, iTunes, TV networks. An episode without issue from one source may have a release 'Proper'd from another which leads to the good file being overwritten. This option is enabled by default to limit overwriting WEBDL media to releases that only come from the original release group.
