### PR TITLE
Change improve post processing by using more snatch history data.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
 * Change only use newznab Api key if needed
 * Change editshow saving empty scene exceptions
 * Change improve TVDB data handling
+* Change improve post processing by using more snatch history data
 
 
 [develop changelog]


### PR DESCRIPTION
Add try to match .nzb or .torrent name in history for pp, fallback to dirname.
Add showObj lookup to scheduled pp.
Add a debug log message for snatched shows found in history during post processing.
Add use filename of largest video file for history lookups.