### PR TITLE
Change showupdate add integrity safeguards and improve image processing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,14 @@
 * Change only use newznab Api key if needed
 * Change editshow saving empty scene exceptions
 * Change improve TVDB data handling
+* Change show update, don't delete any ep in DB if eps are not returned from indexer
+* Change prevent unneeded error message during show update
+* Change improve performance, don't fetch episode list when retrieving a show image
+* Change don't remove episodes from DB with status: SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED
+* Change add additional episode removal protections for TVDb_api v2
+* Change filter SKIPPED items from episode view
+* Change improve clarity of various error message by including relevant show name
+* Change extend WEB PROPER release group check to ignore SD releases
 
 
 [develop changelog]

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -54,7 +54,7 @@ except ImportError:
 
 from sickbeard.exceptions import MultipleShowObjectsException, ex
 from sickbeard import logger, db, notifiers, clients
-from sickbeard.common import USER_AGENT, mediaExtensions, subtitleExtensions, cpu_presets
+from sickbeard.common import USER_AGENT, mediaExtensions, subtitleExtensions, cpu_presets, statusStrings, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED, Quality
 from sickbeard import encodingKludge as ek
 
 from lib.cachecontrol import CacheControl, caches
@@ -1540,3 +1540,11 @@ def set_file_timestamp(filename, min_age=3, new_time=None):
             ek.ek(os.utime, filename, new_time)
     except (StandardError, Exception):
         pass
+
+
+def should_delete_episode(status):
+    s = Quality.splitCompositeStatus(status)
+    if s not in (SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED):
+        return True
+    logger.log('not safe to delete episode from db because of status: %s' % statusStrings[s], logger.DEBUG)
+    return False

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -517,7 +517,7 @@ class GenericMetadata():
             logger.log(u"No thumb is available for this episode, not creating a thumb", logger.DEBUG)
             return False
 
-        thumb_data = metadata_helpers.getShowImage(thumb_url)
+        thumb_data = metadata_helpers.getShowImage(thumb_url, showName=ep_obj.show.name)
 
         result = self._write_image(thumb_data, file_path)
 
@@ -620,7 +620,7 @@ class GenericMetadata():
                            logger.DEBUG)
                 continue
 
-            seasonData = metadata_helpers.getShowImage(season_url)
+            seasonData = metadata_helpers.getShowImage(season_url, showName=show_obj.name)
 
             if not seasonData:
                 logger.log(u"No season poster data available, skipping this season", logger.DEBUG)
@@ -668,7 +668,7 @@ class GenericMetadata():
                            logger.DEBUG)
                 continue
 
-            seasonData = metadata_helpers.getShowImage(season_url)
+            seasonData = metadata_helpers.getShowImage(season_url, showName=show_obj.name)
 
             if not seasonData:
                 logger.log(u"No season banner data available, skipping this season", logger.DEBUG)
@@ -771,7 +771,7 @@ class GenericMetadata():
                 lINDEXER_API_PARMS['language'] = indexer_lang
 
             t = sickbeard.indexerApi(show_obj.indexer).indexer(**lINDEXER_API_PARMS)
-            indexer_show_obj = t[show_obj.indexerid]
+            indexer_show_obj = t[show_obj.indexerid, False]
         except (sickbeard.indexer_error, IOError) as e:
             logger.log(u"Unable to look up show on " + sickbeard.indexerApi(
                 show_obj.indexer).name + ", not downloading images: " + ex(e), logger.ERROR)
@@ -827,7 +827,7 @@ class GenericMetadata():
             if return_links:
                 return image_urls
             else:
-                image_data = metadata_helpers.getShowImage((init_url, image_urls[0])[None is init_url], which)
+                image_data = metadata_helpers.getShowImage((init_url, image_urls[0])[None is init_url], which, show_obj.name)
 
         if None is not image_data:
             return image_data

--- a/sickbeard/metadata/helpers.py
+++ b/sickbeard/metadata/helpers.py
@@ -20,7 +20,7 @@ from sickbeard import helpers
 from sickbeard import logger
 
 
-def getShowImage(url, imgNum=None):
+def getShowImage(url, imgNum=None, showName=None):
 
     if None is url:
         return None
@@ -32,7 +32,7 @@ def getShowImage(url, imgNum=None):
 
     image_data = helpers.getURL(temp_url)
     if None is image_data:
-        logger.log(u'There was an error trying to retrieve the image, aborting', logger.ERROR)
+        logger.log('There was an error trying to retrieve the image%s, aborting' % ('', ' for show: %s' % showName)[None is not showName], logger.ERROR)
         return
 
     return image_data

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -21,6 +21,7 @@ import operator
 import os
 import threading
 import traceback
+import re
 
 import sickbeard
 
@@ -165,7 +166,7 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
         # check if we actually want this proper (if it's the right quality)
         my_db = db.DBConnection()
         sql_results = my_db.select(
-            'SELECT release_group, status, version FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
+            'SELECT release_group, status, version, release_name FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?',
             [cur_proper.indexerid, cur_proper.season, cur_proper.episode])
         if not sql_results:
             continue
@@ -182,7 +183,8 @@ def _get_proper_list(aired_since_shows, recent_shows, recent_anime):
 
         # for webldls, prevent propers from different groups
         if sickbeard.PROPERS_WEBDL_ONEGRP and \
-                old_quality in (Quality.HDWEBDL, Quality.FULLHDWEBDL, Quality.UHD4KWEB) and \
+                (old_quality in (Quality.HDWEBDL, Quality.FULLHDWEBDL, Quality.UHD4KWEB) or
+                     (old_quality == Quality.SDTV and re.search(r'\Wweb.?(dl|rip|.[hx]26[45])\W', str(sql_results[0]['release_name']), re.I))) and \
                 cur_proper.release_group != old_release_group:
             logger.log(log_same_grp, logger.DEBUG)
             continue

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -447,7 +447,7 @@ class MainHandler(WebHandler):
         recently = (yesterday_dt - datetime.timedelta(days=sickbeard.EPISODE_VIEW_MISSED_RANGE)).toordinal()
 
         done_show_list = []
-        qualities = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]
+        qualities = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED, SKIPPED]
 
         myDB = db.DBConnection()
         sql_results = myDB.select(
@@ -475,7 +475,7 @@ class MainHandler(WebHandler):
         # make a dict out of the sql results
         sql_results = [dict(row) for row in sql_results
                        if Quality.splitCompositeStatus(helpers.tryInt(row['status']))[0] not in
-                       [DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, ARCHIVED, IGNORED]]
+                       [DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, ARCHIVED, IGNORED, SKIPPED]]
 
         # multi dimension sort
         sorts = {


### PR DESCRIPTION
Add an episode view filter, improve WEB PROPER selection.

Change show update, don't delete any ep in DB if eps are not returned from indexer.
Change prevent unneeded error message during show update.

Change improve performance, don't fetch episode list when retrieving a show image.
Change don't remove episodes from DB with status: SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED.
Change add additional episode removal protections for TVDb_api v2.

Change filter SKIPPED items from episode view.
Change improve clarity of various error message by including relevant show name.
Change extend WEB PROPER release group check to ignore SD releases.