### PR TITLE
Fix image not loaded from tvdb_api if there is only one poster/banner.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,9 @@
 * Change add nzb.org BoxSD and BoxHD categories
 * Change post processor, ignore symlinks found in process_dir
 * Change file modify date of episodes older than 1970 can be changed to airdate, log warning on set fail
+* Add new parameter 'poster' to indexer api
+* Add optional tvdb_api load season image: lINDEXER_API_PARMS['seasons'] = True
+* Add optional tvdb_api load season wide image: lINDEXER_API_PARMS['seasonwides'] = True
 
 
 [develop changelog]
@@ -98,6 +101,8 @@
 * Update Certifi 2015.11.20.1 (385476b) to 2017.01.23 (9f9dc30)
 * Update Tornado Web Server 4.5.dev1 (92f29b8) to 4.5.dev1 (38e493e)
 * Update unidecode library 0.04.18 to 0.04.20 (1e18d98)
+* Fix image not loaded from tvdb_api if there is only one poster/banner
+* Change prevent setting show/episode attr to None from indexer data
 
 
 ### 0.12.27 (2017-08-22 19:00:00 UTC)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -763,6 +763,8 @@ class GenericMetadata():
             lINDEXER_API_PARMS = sickbeard.indexerApi(show_obj.indexer).api_params.copy()
             if image_type.startswith('fanart'):
                 lINDEXER_API_PARMS['fanart'] = True
+            elif image_type.startswith('poster'):
+                lINDEXER_API_PARMS['posters'] = True
             else:
                 lINDEXER_API_PARMS['banners'] = True
             lINDEXER_API_PARMS['dvdorder'] = 0 != show_obj.dvdorder

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -78,6 +78,11 @@ def dirty_setter(attr_name, types=None):
     return wrapper
 
 
+def dict_prevent_None(d, key, default):
+    v = getattr(d, key, default)
+    return (v, default)[None is v]
+
+
 class TVShow(object):
     def __init__(self, indexer, indexerid, lang=''):
         self._indexerid = int(indexerid)
@@ -925,12 +930,12 @@ class TVShow(object):
             raise sickbeard.indexer_attributenotfound(
                 "Found %s, but attribute 'seriesname' was empty." % (self.indexerid))
 
-        self.classification = getattr(myEp, 'classification', 'Scripted')
-        self.genre = getattr(myEp, 'genre', '')
-        self.network = getattr(myEp, 'network', '')
-        self.runtime = getattr(myEp, 'runtime', '')
+        self.classification = dict_prevent_None(myEp, 'classification', 'Scripted')
+        self.genre = dict_prevent_None(myEp, 'genre', '')
+        self.network = dict_prevent_None(myEp, 'network', '')
+        self.runtime = dict_prevent_None(myEp, 'runtime', '')
 
-        self.imdbid = getattr(myEp, 'imdb_id', '')
+        self.imdbid = dict_prevent_None(myEp, 'imdb_id', '')
 
         if getattr(myEp, 'airs_dayofweek', None) is not None and getattr(myEp, 'airs_time', None) is not None:
             self.airs = ('%s %s' % (myEp['airs_dayofweek'], myEp['airs_time'])).strip()
@@ -938,8 +943,8 @@ class TVShow(object):
         if getattr(myEp, 'firstaired', None) is not None:
             self.startyear = int(str(myEp["firstaired"]).split('-')[0])
 
-        self.status = getattr(myEp, 'status', '')
-        self.overview = getattr(myEp, 'overview', '')
+        self.status = dict_prevent_None(myEp, 'status', '')
+        self.overview = dict_prevent_None(myEp, 'overview', '')
 
     def load_imdb_info(self):
 
@@ -1799,7 +1804,7 @@ class TVEpisode(object):
                        (self.show.indexerid, season, episode, myEp['absolute_number']), logger.DEBUG)
             self.absolute_number = int(myEp['absolute_number'])
 
-        self.name = getattr(myEp, 'episodename', '')
+        self.name = dict_prevent_None(myEp, 'episodename', '')
         self.season = season
         self.episode = episode
 
@@ -1817,7 +1822,7 @@ class TVEpisode(object):
             self.season, self.episode
         )
 
-        self.description = getattr(myEp, 'overview', '')
+        self.description = dict_prevent_None(myEp, 'overview', '')
 
         firstaired = getattr(myEp, 'firstaired', None)
         if None is firstaired or firstaired in '0000-00-00':


### PR DESCRIPTION
Add new parameter 'poster' to indexer api.
Add optional tvdb_api load season image: lINDEXER_API_PARMS['seasons'] = True.
Add optional tvdb_api load season wide image: lINDEXER_API_PARMS['seasonwides'] = True.
Change prevent setting show/episode attr to None from indexer data.