### PR TITLE
Fix FreeBSD initscript to use interpreter properly

### DIFF
--- a/init-scripts/init.freebsd
+++ b/init-scripts/init.freebsd
@@ -32,8 +32,9 @@ load_rc_config ${name}
 : ${sickgear_datadir:="${sickgear_dir}"}
 : ${sickgear_pidfile:="${sickgear_dir}/sickgear.pid"}
 
-command="/usr/local/bin/python"
-command_args="${sickgear_dir}/SickBeard.py --daemon --pidfile ${sickgear_pidfile}"
+command="${sickgear_dir}/SickBeard.py"
+command_interpreter="/usr/local/bin/python"
+command_args="--daemon --pidfile ${sickgear_pidfile}"
 
 # Add datadir to the command if set
 [ ! -z "${sickgear_datadir}" ] && \


### PR DESCRIPTION
The default initscript was not working, and incorrectly matching on my couchpotato service as well as itself. Fixed it by using command_interpreter so that it now only sees its own PID.