### PR TITLE
Change allow Cheetah template engine version 2 and newer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,7 @@
 * Add shows that have no replacement ID can be ignored at "Manage/Show Processes", the menu bar warn icon hides if all are ignored
 * Change FreeBSD initscript to use command_interpreter
 * Add Slack notifier
+* Change allow Cheetah template engine version 2 and newer
 
 
 [develop changelog]

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -50,7 +50,7 @@ except (StandardError, Exception):
 try:
     import Cheetah
 
-    if Cheetah.Version[0] != '2':
+    if Cheetah.Version[0] < '2':
         raise ValueError
 except ValueError:
     print('Sorry, requires Python module Cheetah 2.1.0 or newer.')


### PR DESCRIPTION
Cheetah has been forked and enjoys new support, a drop in replacement and compiled binaries improve page rendering performance for SickGear.

Download a whl version for Py Version *cp27* (Py2.7) from https://pypi.python.org/pypi/Cheetah3
To upgrade the existing...
1) Shutdown SickGear
2) Run: python -m pip install Cheetah3-<version>-cp27-cp27m-<platform>.whl
   e.g. for Win 64bit ... python -m pip install Cheetah3-3.0.0-cp27-cp27m-win_amd64.whl
3) Start SickGear