### PR TITLE
Add quality tag to archived items, improve displayShow/"Change select…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,16 @@
 * Change add tips for what to use for Growl notifications on Windows
 * Change if a newly added show is not found on indexer, remove already created empty folder
 * Change parse 1080p Bluray AVC/VC1 to a quality instead of unknown
+* Add quality tag to archived items, improve displayShow/"Change selected episodes to"
+* Use to prevent "Update to" on those select episodes while preserving the downloaded quality
+* Change group "Downloaded" status qualities into one section
+* Add "Downloaded/with archived quality" to set shows as downloaded using quality of archived status
+* Add "Archived with/downloaded quality" to set shows as archived using quality of downloaded status
+* Add "Archived with/default (min. initial quality of show here)"
+* Change when settings/Post Processing/File Handling/Status of removed episodes/Set Archived is enabled, set status and quality accordingly
+* Add downloaded and archived statuses to Manage/Episode Status
+* Add quality pills to Manage/Episode Status
+* Change Manage/Episode Status season output format to be more readable
 
 
 [develop changelog]

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -17,7 +17,7 @@
 #set global $page_body_attr = 'display-show" class="' + $css
 #set theme_suffix = ('', '-dark')['dark' == $sg_str('THEME_NAME', 'dark')]
 ##
-#import os.path, os
+#import os.path, os, re
 #include $os.path.join($sg_str('PROG_DIR'), 'gui/slick/interfaces/default/inc_top.tmpl')
 <input type="hidden" id="sbRoot" value="$sbRoot">
 <script>
@@ -389,13 +389,22 @@
 
 	<div id="change-status" class="pull-left">
 		<p style="margin-bottom:5px">Change selected episodes to</p>
-		<select id="statusSelect" class="form-control form-control-inline input-sm">
-#for $curStatus in [$WANTED, $SKIPPED, $ARCHIVED, $IGNORED, $FAILED] + sorted($Quality.DOWNLOADED)
-    #if $DOWNLOADED == $curStatus
-        #continue
-    #end if
+		<select id="statusSelect" class="form-control form-control-inline input-sm showlist-select">
+#for $curStatus in [$WANTED, $SKIPPED, $IGNORED, $FAILED]
 			<option value="$curStatus">$statusStrings[$curStatus]</option>
 #end for
+			<optgroup label="Downloaded">
+#for $curStatus in sorted($Quality.DOWNLOADED)
+    #if $DOWNLOADED != $curStatus
+				<option value="$curStatus">$re.sub('Downloaded\s*\(([^\)]+)\)', r'\1', $statusStrings[$curStatus])</option>
+    #end if
+#end for
+			<option value="$DOWNLOADED">with archived quality</option>
+			</optgroup>
+			<optgroup label="Archived with">
+				<option value="$ARCHIVED">downloaded quality</option>
+				<option value="-$ARCHIVED">default ($min_initial)</option>
+			</optgroup>
 		</select>
 		<input type="hidden" id="showID" value="$show.indexerid">
 		<input type="hidden" id="indexer" value="$show.indexer">

--- a/gui/slick/interfaces/default/history.tmpl
+++ b/gui/slick/interfaces/default/history.tmpl
@@ -3,7 +3,7 @@
 
 #import sickbeard
 #from sickbeard import history, providers, sbdatetime
-#from sickbeard.common import Quality, statusStrings, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, SUBTITLED, ARCHIVED, FAILED
+#from sickbeard.common import Quality, statusStrings, SNATCHED_ANY, SNATCHED_PROPER, DOWNLOADED, SUBTITLED, ARCHIVED, FAILED
 #from sickbeard.providers import generic
 <% def sg_var(varname, default=False): return getattr(sickbeard, varname, default) %>#slurp#
 <% def sg_str(varname, default=''): return getattr(sickbeard, varname, default) %>#slurp#
@@ -143,7 +143,7 @@
             #end if
         #else
             #if 0 < $hItem['provider']
-                #if $curStatus in [$SNATCHED, $SNATCHED_PROPER, $SNATCHED_BEST, $FAILED]
+                #if $curStatus in [$SNATCHED_ANY, $FAILED]
                     #set $provider = $providers.getProviderClass($generic.GenericProvider.make_id($hItem['provider']))
                     #if None is not $provider
 					<img src="$sbRoot/images/providers/<%= provider.image_name() %>" width="16" height="16" /><span>$provider.name</span>
@@ -195,14 +195,14 @@
         #for $action in reversed($hItem['actions'])
             #set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($action['action']))
             #set $basename = $os.path.basename($action['resource'])
-            #if $curStatus in [$SNATCHED, $SNATCHED_PROPER, $SNATCHED_BEST, $FAILED]
+            #if $curStatus in $SNATCHED_ANY + [$FAILED]
                 #set $provider = $providers.getProviderClass($generic.GenericProvider.make_id($action['provider']))
                 #if None is not $provider
                     #set $prov_list += ['<span%s><img class="help" src="%s/images/providers/%s" width="16" height="16" alt="%s" title="%s.. %s: %s" /></span>'\
                         % (('', ' class="fail"')[$FAILED == $curStatus], $sbRoot, $provider.image_name(), $provider.name,
                         ('%s%s' % ($order, 'th' if $order in [11, 12, 13] or str($order)[-1] not in $ordinal_indicators else $ordinal_indicators[str($order)[-1]]), 'Snatch failed')[$FAILED == $curStatus],
                         $provider.name, $basename)]
-                    #set $order += (0, 1)[$curStatus in ($SNATCHED, $SNATCHED_PROPER, $SNATCHED_BEST)]
+                    #set $order += (0, 1)[$curStatus in $SNATCHED_ANY]
                 #else
 					#set $prov_list += ['<img src="%s/images/providers/missing.png" width="16" height="16" alt="missing provider" title="missing provider" />'\
 					    % $sbRoot]

--- a/gui/slick/interfaces/default/inc_bottom.tmpl
+++ b/gui/slick/interfaces/default/inc_bottom.tmpl
@@ -13,8 +13,8 @@
 		<div class="footer clearfix">
 #set $my_db = $db.DBConnection()
 #set $today = str($datetime.date.today().toordinal())
-#set status_quality = '(%s)' % ','.join([str(quality) for quality in $Quality.SNATCHED + $Quality.SNATCHED_PROPER + $Quality.SNATCHED_BEST])
-#set status_download = '(%s)' % ','.join([str(quality) for quality in $Quality.DOWNLOADED + [$ARCHIVED]])
+#set status_quality = '(%s)' % ','.join([str(quality) for quality in $Quality.SNATCHED_ANY])
+#set status_download = '(%s)' % ','.join([str(quality) for quality in $Quality.DOWNLOADED + $Quality.ARCHIVED])
 #set $sql_statement = 'SELECT '\
     + '(SELECT COUNT(*) FROM tv_episodes WHERE season > 0 AND episode > 0 AND airdate > 1 AND status IN %s) AS ep_snatched, '\
     % $status_quality\

--- a/gui/slick/interfaces/default/inc_displayShow.tmpl
+++ b/gui/slick/interfaces/default/inc_displayShow.tmpl
@@ -23,7 +23,7 @@
     #set $ep_str = '%sx%s' % ($ep['season'], $ep['episode'])
     #set $epLoc = $ep['location']
     #set never_aired = 0 < int($ep['season']) and 1 == int($ep['airdate'])
-		<tr class="#echo ' '.join([$Overview.overviewStrings[$ep_cats[$ep_str]], ('', 'airdate-never')[$never_aired], ('', 'archived')[ARCHIVED == int($ep['status'])]])#">
+		<tr class="#echo ' '.join([$Overview.overviewStrings[$ep_cats[$ep_str]], ('', 'airdate-never')[$never_aired], ('', 'archived')[$ARCHIVED == $Quality.splitCompositeStatus(int($ep['status']))[0]]])#">
 			<td class="col-checkbox">
     #if $UNAIRED != int($ep['status'])
 				<input type="checkbox" class="epCheck" id="$ep_str" name="$ep_str">
@@ -105,7 +105,7 @@
     #slurp
     #set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($ep['status']))
     #if Quality.NONE != $curQuality
-			<td class="col-status">#if SUBTITLED == $curStatus#<span class="addQTip" title="$statusStrings[$curStatus]"><i class="sgicon-subtitles" style="vertical-align:middle"></i></span>#else#$statusStrings[$curStatus].replace('Downloaded', '')#end if# <span class="quality $Quality.get_quality_css($curQuality)#if $downloaded# addQTip" title="$downloaded#end if#">$Quality.qualityStrings[$curQuality]</span></td>
+			<td class="col-status">#if $SUBTITLED == $curStatus#<span class="addQTip" title="$statusStrings[$curStatus]"><i class="sgicon-subtitles" style="vertical-align:middle"></i></span>#else#$statusStrings[$curStatus].replace('Downloaded', '')#end if# <span class="quality $Quality.get_quality_css($curQuality)#if $downloaded# addQTip" title="$downloaded#end if#">$Quality.qualityStrings[$curQuality]</span></td>
     #else
 			<td class="col-status">$statusStrings[$curStatus]</td>
     #end if

--- a/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
+++ b/gui/slick/interfaces/default/manage_episodeStatuses.tmpl
@@ -19,7 +19,7 @@
 #if not $whichStatus or ($whichStatus and not $ep_counts)
 ##
     #if $whichStatus:
-	<h3>no episodes have status <span class="grey-text">$common.statusStrings[$int($whichStatus)].lower()</span></h3>
+	<h3>no episodes have status <span class="grey-text">$common.statusStrings[$whichStatus].lower()</span></h3>
     #end if
 
 	<form action="$sbRoot/manage/episodeStatuses" method="get">
@@ -27,7 +27,7 @@
 		Manage episodes with status
 		<select name="whichStatus" class="form-control form-control-inline input-sm" style="margin:0 10px">
 
-    #for $curStatus in [$common.SKIPPED, $common.UNKNOWN, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
+    #for $curStatus in [$common.SKIPPED, $common.UNKNOWN, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED, $common.DOWNLOADED]:
 			<option value="$curStatus"#echo ('', ' selected="selected"')[$curStatus == $default_manage]#>$common.statusStrings[$curStatus]</option>
     #end for
 
@@ -45,11 +45,16 @@
     #end if
 
     #set $statusList = [$common.SKIPPED, $common.ARCHIVED, $common.IGNORED]
-    #if $int($whichStatus) in $statusList
-        $statusList.remove($int($whichStatus))
+    #if $common.DOWNLOADED == $whichStatus:
+        #set $statusList = [$common.ARCHIVED]
+    #elif $common.ARCHIVED == $whichStatus:
+        #set $statusList = [$common.SKIPPED, $common.DOWNLOADED, $common.ARCHIVED, $common.IGNORED]
+    #end if
+    #if $whichStatus in $statusList
+        $statusList.remove($whichStatus)
     #end if
 
-    #if $int($whichStatus) in [$common.SNATCHED, $common.SNATCHED_PROPER, $common.SNATCHED_BEST]
+    #if $whichStatus in $common.SNATCHED_ANY
         $statusList.append($common.FAILED)
     #end if
 
@@ -58,7 +63,7 @@
 	<form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
 		<input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus">
 
-		<h3><span class="grey-text">$ep_count</span> episode#echo ('s', '')[1 == $ep_count]# marked <span class="grey-text">$common.statusStrings[$int($whichStatus)].lower()</span> in <span class="grey-text">${len($sorted_show_ids)}</span> show#echo ('s', '')[1 == len($sorted_show_ids)]#</h3>
+		<h3><span class="grey-text">$ep_count</span> episode#echo ('s', '')[1 == $ep_count]# marked <span class="grey-text">$common.statusStrings[$whichStatus].lower()</span> in <span class="grey-text">${len($sorted_show_ids)}</span> show#echo ('s', '')[1 == len($sorted_show_ids)]#</h3>
 
 		<input type="hidden" id="row_class" value="$row_class">
 
@@ -71,12 +76,14 @@
 			</select>
 			<input class="btn btn-inline go" type="submit" value="Go">
 
+    #if $common.DOWNLOADED != $whichStatus:
 			<span class="red-text" style="margin:0 0 0 30px">Override checked status to</span>
 			<select name="wantedStatus" class="form-control form-control-inline input-sm" style="margin:0 10px 0 5px">
 				<option value="$common.UNKNOWN">nothing</option>
 				<option value="$common.WANTED">$common.statusStrings[$common.WANTED]</option>
 			</select>
 			<input class="btn btn-inline go" type="submit" value="Go">
+	#end if
 		</div>
 
 		<div class="form-group">

--- a/gui/slick/js/manageEpisodeStatuses.js
+++ b/gui/slick/js/manageEpisodeStatuses.js
@@ -1,6 +1,6 @@
-$(document).ready(function() { 
+$(document).ready(function() {
 
-	function make_row(indexer_id, season, episode, name, checked, airdate_never) {
+	function make_row(indexer_id, season, episode, name, checked, airdate_never, qualityCss, qualityStr, sxe) {
 		var checkedbox = (checked ? ' checked' : ''),
 			row_class = $('#row_class').val(),
 			ep_id = season + 'x' + episode;
@@ -11,8 +11,10 @@ $(document).ready(function() {
 					+ ' class="' + indexer_id + '-epcheck"'
 					+ ' name="' + indexer_id + '-' + ep_id + '"'
 					+ checkedbox+'></td>'
-			+ '  <td>' + ep_id + '</td>'
-			+ '  <td class="tableright" style="width: 100%">' + name + (airdate_never ? ' (<strong><em>airdate is never, this should change in time</em></strong>)' : '') + '</td>'
+			+ '  <td class="text-nowrap">' + sxe + '</td>'
+			+ '  <td class="tableright" style="width: 100%">'
+			+ ' <span class="quality show-quality ' + qualityCss + ' text-nowrap">' +  qualityStr + '</span>'
+			+ name + (airdate_never ? ' (<strong><em>airdate is never, this should change in time</em></strong>)' : '') + '</td>'
 			+ ' </tr>';
 	}
 
@@ -49,7 +51,7 @@ $(document).ready(function() {
 				function (data) {
 					$.each(data, function(season, eps){
 						$.each(eps, function(episode, meta) {
-							show_header.after(make_row(cur_indexer_id, season, episode, meta.name, checked, meta.airdate_never));
+							show_header.after(make_row(cur_indexer_id, season, episode, meta.name, checked, meta.airdate_never, meta.qualityCss, meta.qualityStr, meta.sxe));
 						});
 					});
 					$('input#' + match[0]).val('more' == action ? 'Expand' : 'Collapse');

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -67,6 +67,7 @@ SNATCHED_PROPER = 9  # qualified with quality
 SUBTITLED = 10  # qualified with quality
 FAILED = 11  # episode downloaded or snatched we don't want
 SNATCHED_BEST = 12  # episode redownloaded using best quality
+SNATCHED_ANY = [SNATCHED, SNATCHED_PROPER, SNATCHED_BEST]
 
 NAMING_REPEAT = 1
 NAMING_EXTEND = 2
@@ -367,18 +368,22 @@ class Quality:
                 quality = Quality.assumeQuality(file_path)
         return Quality.compositeStatus(DOWNLOADED, quality)
 
-    DOWNLOADED = None
     SNATCHED = None
     SNATCHED_PROPER = None
-    FAILED = None
     SNATCHED_BEST = None
+    SNATCHED_ANY = None
+    DOWNLOADED = None
+    ARCHIVED = None
+    FAILED = None
 
 
-Quality.DOWNLOADED = [Quality.compositeStatus(DOWNLOADED, x) for x in Quality.qualityStrings.keys()]
 Quality.SNATCHED = [Quality.compositeStatus(SNATCHED, x) for x in Quality.qualityStrings.keys()]
 Quality.SNATCHED_PROPER = [Quality.compositeStatus(SNATCHED_PROPER, x) for x in Quality.qualityStrings.keys()]
-Quality.FAILED = [Quality.compositeStatus(FAILED, x) for x in Quality.qualityStrings.keys()]
 Quality.SNATCHED_BEST = [Quality.compositeStatus(SNATCHED_BEST, x) for x in Quality.qualityStrings.keys()]
+Quality.SNATCHED_ANY = Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST
+Quality.DOWNLOADED = [Quality.compositeStatus(DOWNLOADED, x) for x in Quality.qualityStrings.keys()]
+Quality.ARCHIVED = [Quality.compositeStatus(ARCHIVED, x) for x in Quality.qualityStrings.keys()]
+Quality.FAILED = [Quality.compositeStatus(FAILED, x) for x in Quality.qualityStrings.keys()]
 
 SD = Quality.combineQualities([Quality.SDTV, Quality.SDDVD], [])
 HD = Quality.combineQualities(
@@ -409,29 +414,26 @@ class StatusStrings:
         self.statusStrings = {UNKNOWN: 'Unknown',
                               UNAIRED: 'Unaired',
                               SNATCHED: 'Snatched',
-                              DOWNLOADED: 'Downloaded',
-                              SKIPPED: 'Skipped',
                               SNATCHED_PROPER: 'Snatched (Proper)',
-                              WANTED: 'Wanted',
+                              SNATCHED_BEST: 'Snatched (Best)',
+                              DOWNLOADED: 'Downloaded',
                               ARCHIVED: 'Archived',
+                              SKIPPED: 'Skipped',
+                              WANTED: 'Wanted',
                               IGNORED: 'Ignored',
                               SUBTITLED: 'Subtitled',
-                              FAILED: 'Failed',
-                              SNATCHED_BEST: 'Snatched (Best)'}
+                              FAILED: 'Failed'}
 
     def __getitem__(self, name):
-        if name in Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
+        if name in Quality.SNATCHED_ANY + Quality.DOWNLOADED + Quality.ARCHIVED:
             status, quality = Quality.splitCompositeStatus(name)
             if quality == Quality.NONE:
                 return self.statusStrings[status]
-            else:
-                return '%s (%s)' % (self.statusStrings[status], Quality.qualityStrings[quality])
-        else:
-            return self.statusStrings[name] if self.statusStrings.has_key(name) else ''
+            return '%s (%s)' % (self.statusStrings[status], Quality.qualityStrings[quality])
+        return self.statusStrings[name] if self.statusStrings.has_key(name) else ''
 
     def has_key(self, name):
-        return name in self.statusStrings or name in Quality.DOWNLOADED or name in Quality.SNATCHED \
-            or name in Quality.SNATCHED_PROPER or name in Quality.SNATCHED_BEST
+        return name in self.statusStrings or name in Quality.SNATCHED_ANY + Quality.DOWNLOADED + Quality.ARCHIVED
 
 
 statusStrings = StatusStrings()

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -55,7 +55,8 @@ except ImportError:
 
 from sickbeard.exceptions import MultipleShowObjectsException, ex
 from sickbeard import logger, db, notifiers, clients
-from sickbeard.common import USER_AGENT, mediaExtensions, subtitleExtensions, cpu_presets, statusStrings, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED, Quality
+from sickbeard.common import USER_AGENT, mediaExtensions, subtitleExtensions, cpu_presets, statusStrings, \
+    SNATCHED_ANY, DOWNLOADED, ARCHIVED, IGNORED, Quality
 from sickbeard import encodingKludge as ek
 
 from lib.cachecontrol import CacheControl, caches
@@ -1519,7 +1520,7 @@ def set_file_timestamp(filename, min_age=3, new_time=None):
 
 def should_delete_episode(status):
     s = Quality.splitCompositeStatus(status)
-    if s not in (SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, ARCHIVED, IGNORED):
+    if s not in SNATCHED_ANY + [DOWNLOADED, ARCHIVED, IGNORED]:
         return True
     logger.log('not safe to delete episode from db because of status: %s' % statusStrings[s], logger.DEBUG)
     return False

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -657,7 +657,7 @@ class PostProcessor(object):
         """
 
         # if there is a quality available in the status then we don't need to bother guessing from the filename
-        if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+        if ep_obj.status in common.Quality.SNATCHED_ANY:
             old_status, ep_quality = common.Quality.splitCompositeStatus(ep_obj.status)  # @UnusedVariable
             if common.Quality.UNKNOWN != ep_quality:
                 self._log(
@@ -742,7 +742,7 @@ class PostProcessor(object):
         """
 
         # if SickGear snatched this then assume it's safe
-        if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+        if ep_obj.status in common.Quality.SNATCHED_ANY:
             self._log(u'SickGear snatched this episode, marking it safe to replace', logger.DEBUG)
             return True
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -35,7 +35,7 @@ from sickbeard.exceptions import ex
 from sickbeard import logger
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 from sickbeard import common
-from sickbeard.common import SNATCHED, SNATCHED_PROPER, SNATCHED_BEST
+from sickbeard.common import SNATCHED_ANY
 from sickbeard.history import reset_status
 from sickbeard.exceptions import MultipleShowObjectsException
 
@@ -173,8 +173,7 @@ class ProcessTVShow(object):
         sql_results = my_db.select(
             'SELECT showid FROM history' +
             ' WHERE resource = ?' +
-            ' AND (%s)' % ' OR '.join('action LIKE "%%%02d"' % x for x in (
-                SNATCHED, SNATCHED_PROPER, SNATCHED_BEST)) +
+            ' AND (%s)' % ' OR '.join('action LIKE "%%%02d"' % x for x in SNATCHED_ANY) +
             ' ORDER BY rowid', [name])
         if sql_results:
             try:

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -352,7 +352,7 @@ def wanted_episodes(show, from_date, make_dict=False, unaired=False):
     else:
         wanted = []
     total_wanted = total_replacing = total_unaired = 0
-    downloaded_status_list = (common.DOWNLOADED, common.SNATCHED, common.SNATCHED_PROPER, common.SNATCHED_BEST)
+    downloaded_status_list = common.SNATCHED_ANY + [common.DOWNLOADED]
     for result in sql_results:
         not_downloaded = True
         cur_composite_status = int(result['status'])

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -36,7 +36,7 @@ from sickbeard import classes
 from sickbeard import processTV
 from sickbeard import network_timezones, sbdatetime
 from sickbeard.exceptions import ex
-from sickbeard.common import SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, SKIPPED, UNAIRED, IGNORED, ARCHIVED, WANTED, UNKNOWN
+from sickbeard.common import SNATCHED, SNATCHED_ANY, SNATCHED_PROPER, SNATCHED_BEST, DOWNLOADED, SKIPPED, UNAIRED, IGNORED, ARCHIVED, WANTED, UNKNOWN
 from sickbeard.helpers import remove_article
 from common import Quality, qualityPresetStrings, statusStrings
 from sickbeard.indexers.indexer_config import *
@@ -562,7 +562,7 @@ def _replace_statusStrings_with_statusCodes(statusStrings):
     if "wanted" in statusStrings:
         statusCodes.append(WANTED)
     if "archived" in statusStrings:
-        statusCodes.append(ARCHIVED)
+        statusCodes += Quality.ARCHIVED
     if "ignored" in statusStrings:
         statusCodes.append(IGNORED)
     if "unaired" in statusStrings:
@@ -703,7 +703,7 @@ class CMD_ComingEpisodes(ApiCall):
         recently = (yesterday_dt - datetime.timedelta(days=sickbeard.EPISODE_VIEW_MISSED_RANGE)).toordinal()
 
         done_show_list = []
-        qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]
+        qualList = Quality.SNATCHED + Quality.DOWNLOADED + Quality.ARCHIVED + [IGNORED]
 
         myDB = db.DBConnection()
         sql_results = myDB.select(
@@ -2469,7 +2469,7 @@ class CMD_ShowStats(ApiCall):
         episode_status_counts_total = {}
         episode_status_counts_total["total"] = 0
         for status in statusStrings.statusStrings.keys():
-            if status in [UNKNOWN, DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST]:
+            if status in SNATCHED_ANY + [UNKNOWN, DOWNLOADED]:
                 continue
             episode_status_counts_total[status] = 0
 
@@ -2485,7 +2485,7 @@ class CMD_ShowStats(ApiCall):
         # add all snatched qualities
         episode_qualities_counts_snatch = {}
         episode_qualities_counts_snatch["total"] = 0
-        for statusCode in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
+        for statusCode in Quality.SNATCHED_ANY:
             status, quality = Quality.splitCompositeStatus(statusCode)
             if quality in [Quality.NONE]:
                 continue
@@ -2503,7 +2503,7 @@ class CMD_ShowStats(ApiCall):
             if status in Quality.DOWNLOADED:
                 episode_qualities_counts_download["total"] += 1
                 episode_qualities_counts_download[int(row["status"])] += 1
-            elif status in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
+            elif status in Quality.SNATCHED_ANY:
                 episode_qualities_counts_snatch["total"] += 1
                 episode_qualities_counts_snatch[int(row["status"])] += 1
             elif status == 0:  # we dont count NONE = 0 = N/A
@@ -2655,12 +2655,12 @@ class CMD_ShowsStats(ApiCall):
             [show for show in sickbeard.showList if show.paused == 0 and show.status != "Ended"])
         stats["ep_downloaded"] = myDB.select("SELECT COUNT(*) FROM tv_episodes WHERE status IN (" + ",".join(
             [str(show) for show in
-             Quality.DOWNLOADED + [ARCHIVED]]) + ") AND season != 0 and episode != 0 AND airdate <= " + today + "")[0][
+             Quality.DOWNLOADED + Quality.ARCHIVED]) + ") AND season != 0 and episode != 0 AND airdate <= " + today + "")[0][
             0]
         stats["ep_total"] = myDB.select(
             "SELECT COUNT(*) FROM tv_episodes WHERE season != 0 AND episode != 0 AND (airdate != 1 OR status IN (" + ",".join(
-                [str(show) for show in (Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST) + [
-                    ARCHIVED]]) + ")) AND airdate <= " + today + " AND status != " + str(IGNORED) + "")[0][0]
+                [str(show) for show in Quality.SNATCHED_ANY + Quality.DOWNLOADED + Quality.ARCHIVED]) +
+            ")) AND airdate <= " + today + " AND status != " + str(IGNORED) + "")[0][0]
 
         return _responds(RESULT_SUCCESS, stats)
 


### PR DESCRIPTION
…ed episodes to".

Use to prevent "Update to" on those select episodes while preserving the downloaded quality.
Change group "Downloaded" status qualities into one section.
Add "Downloaded/with archived quality" to set shows as downloaded using quality of archived status.
Add "Archived with/downloaded quality" to set shows as archived using quality of downloaded status.
Add "Archived with/default (min. initial quality of show here)".
Change when settings/Post Processing/File Handling/Status of removed episodes/Set Archived is enabled, set status and quality accordingly.
Add downloaded and archived statuses to Manage/Episode Status.
Add quality pills to Manage/Episode Status.
Change Manage/Episode Status season output format to be more readable.