### PR TITLE
Add support for a testing.db version (>=100000).

### DIFF
--- a/sickbeard/databases/cache_db.py
+++ b/sickbeard/databases/cache_db.py
@@ -22,6 +22,7 @@ import re
 
 MIN_DB_VERSION = 1
 MAX_DB_VERSION = 4
+TEST_BASE_VERSION = None  # the base production db version, only needed for TEST db versions (>=100000)
 
 
 # Add new migrations at the bottom of the list; subclass the previous migration.

--- a/sickbeard/databases/failed_db.py
+++ b/sickbeard/databases/failed_db.py
@@ -21,6 +21,7 @@ from sickbeard.common import Quality
 
 MIN_DB_VERSION = 1
 MAX_DB_VERSION = 1
+TEST_BASE_VERSION = None  # the base production db version, only needed for TEST db versions (>=100000)
 
 # Add new migrations at the bottom of the list; subclass the previous migration.
 class InitialSchema(db.SchemaUpgrade):

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -28,6 +28,7 @@ from sickbeard.name_parser.parser import NameParser, InvalidNameException, Inval
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
 MAX_DB_VERSION = 20008
+TEST_BASE_VERSION = None  # the base production db version, only needed for TEST db versions (>=100000)
 
 
 class MainSanityCheck(db.DBSanityCheck):

--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -20,6 +20,7 @@
 from __future__ import print_function
 import unittest
 import test_lib as test
+from sickbeard import cache_db, mainDB, failed_db
 
 
 class DBBasicTests(test.SickbeardTestDBCase):
@@ -28,9 +29,16 @@ class DBBasicTests(test.SickbeardTestDBCase):
         super(DBBasicTests, self).setUp()
         self.db = test.db.DBConnection()
 
+    def is_testdb(self, version):
+        if isinstance(version, (int, long)):
+            return 100000 <= version
+
     def test_select(self):
         self.db.select('SELECT * FROM tv_episodes WHERE showid = ? AND location != ""', [0000])
         self.db.close()
+        self.assertEqual(cache_db.TEST_BASE_VERSION is not None, self.is_testdb(cache_db.MAX_DB_VERSION))
+        self.assertEqual(mainDB.TEST_BASE_VERSION is not None, self.is_testdb(mainDB.MAX_DB_VERSION))
+        self.assertEqual(failed_db.TEST_BASE_VERSION is not None, self.is_testdb(failed_db.MAX_DB_VERSION))
 
 if __name__ == '__main__':
     print('==================')


### PR DESCRIPTION
A testing.db has a one time stand-alone version number.
None matching test db to required db will always downgrade to release db (after that the normal up/downgrade db process is run).
Add TEST_BASE_VERSION to all db's, used by test versions and set to the base production db version that the test db is based on.
Add a unit_test to make sure a test_base_version is set for test db's.
Change load rollback module only once.