### PR TITLE
Change prefer modern html5lib over old to prevent display show issue …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-﻿### 0.15.13 (2018-04-18 13:50:00 UTC)
+﻿### 0.15.14 (2018-04-20 12:00:00 UTC)
+
+* Change prefer modern html5lib over old to prevent display show issue on systems that fail to clean libs
+
+
+### 0.15.13 (2018-04-18 13:50:00 UTC)
 
 * Fix API endpoints for sg.exceptions and exceptions
 * Change improve searching torrent provider BTScene

--- a/lib/bs4/builder/_html5lib.py
+++ b/lib/bs4/builder/_html5lib.py
@@ -30,13 +30,14 @@ from bs4.element import (
     )
 
 try:
-    # Pre-0.99999999
-    from html5lib.treebuilders import _base as treebuilder_base
-    new_html5lib = False
-except ImportError, e:
     # 0.99999999 and up
     from html5lib.treebuilders import base as treebuilder_base
-    new_html5lib = True
+    old_html5lib = False
+except ImportError:
+    # Pre-0.99999999
+    from html5lib.treebuilders import _base as treebuilder_base
+    old_html5lib = True
+
 
 class HTML5TreeBuilder(HTMLTreeBuilder):
     """Use html5lib to build a tree."""
@@ -65,7 +66,7 @@ class HTML5TreeBuilder(HTMLTreeBuilder):
 
         extra_kwargs = dict()
         if not isinstance(markup, unicode):
-            if new_html5lib:
+            if not old_html5lib:
                 extra_kwargs['override_encoding'] = self.user_specified_encoding
             else:
                 extra_kwargs['encoding'] = self.user_specified_encoding


### PR DESCRIPTION
…on systems that fail to clean libs.

In rare cases, systems *fail* to remove the deprecated "_base.pyc" file (and probably others) in \lib\html5lib\treebuilders\. Therefore, the startup cleanup process will now list files that cannot be auto deleted - user must then manually delete files listed in "__README-DANGER.txt".