### PR TITLE
Include title in tweet notification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Remove redundant tvdb_api v1
 * Change update Emby api
 * Fix update CF IUAM handler
+* Fix issue with duplicate tweets
 
 
 ### 0.20.10 (2019-11-25 23:45:00 UTC)

--- a/sickbeard/notifiers/tweet.py
+++ b/sickbeard/notifiers/tweet.py
@@ -97,7 +97,7 @@ class TwitterNotifier(Notifier):
 
         # don't use title with updates or testing, as only one str is used
         body = '::'.join(([], [sickbeard.TWITTER_PREFIX])[bool(sickbeard.TWITTER_PREFIX)]
-                         + [body.replace('#: ', ': ') if 'SickGear' in title else body])
+                         + [title] + [body.replace('#: ', ': ') if 'SickGear' in title else body])
 
         username = self.consumer_key
         password = self.consumer_secret


### PR DESCRIPTION
Tweet notifications for any action regarding a particular file have identical content due to the title not being included. This leads to the tweets being rejected by Twitter.