### PR TITLE
Fix Kodi meta Nfo files to workaround a Kodi library update crash bug…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
-﻿### 0.21.1 (2020-01-10 14:45:00 UTC)
+﻿### 0.21.2 (2020-01-12 14:00:00 UTC)
+
+* Fix Kodi meta Nfo files to workaround a Kodi library update crash bug that may occur on particular systems
+
+
+### 0.21.1 (2020-01-10 14:45:00 UTC)
 
 * Fix viewing an show added before any application configuration is saved (very rare under normal use)
 

--- a/sickgear.py
+++ b/sickgear.py
@@ -529,6 +529,9 @@ class SickGear(object):
                                                             target=sickbeard.history.history_snatched_proper_fix)
             history_snatched_proper_task.start()
 
+        if not db.DBConnection().has_flag('kodi_nfo_default_removed'):
+            sickbeard.metadata.kodi.remove_default_attr()
+
         if sickbeard.USE_FAILED_DOWNLOADS:
             failed_history.remove_old_history()
 


### PR DESCRIPTION
… that may occur on particular systems.

Change use attribute `default` in Kodi xml .nfo files only when absolutely needed.