### PR TITLE
rtorrent: use relative rpc imports

### DIFF
--- a/lib/rtorrent/common.py
+++ b/lib/rtorrent/common.py
@@ -17,7 +17,8 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-from compat import is_py3, urlparse, urlunparse, ParseResult
+
+from .compat import is_py3, urlparse, urlunparse, ParseResult
 
 import os
 

--- a/lib/rtorrent/err.py
+++ b/lib/rtorrent/err.py
@@ -17,8 +17,7 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-from common import convert_version_tuple_to_str
+from .common import convert_version_tuple_to_str
 
 
 class RTorrentVersionError(Exception):

--- a/lib/rtorrent/file.py
+++ b/lib/rtorrent/file.py
@@ -19,8 +19,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from .common import safe_repr
-from .rpc import Method
-import rpc
+from .rpc import Method, Multicall
 
 
 class File(object):
@@ -43,7 +42,7 @@ class File(object):
 
         @return: None
         """
-        mc = rpc.Multicall(self)
+        mc = Multicall(self)
 
         for method in filter(lambda m: m.is_retriever() and m.is_available(self._rt_obj), methods):
             mc.add(method, self.rpc_id)

--- a/lib/rtorrent/group.py
+++ b/lib/rtorrent/group.py
@@ -18,8 +18,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from .rpc import Method
-import rpc
+from .rpc import Method, _build_rpc_methods, Multicall
 
 
 class Group(object):
@@ -42,7 +41,7 @@ class Group(object):
         ]
 
         # noinspection PyProtectedMember
-        rpc._build_rpc_methods(self, self.methods)
+        _build_rpc_methods(self, self.methods)
 
         # Setup multicall_add method
         caller = (lambda mc, method, *args: mc.add(method, *args))
@@ -52,7 +51,7 @@ class Group(object):
         return 'group.' + self.name + '.ratio.'
 
     def update(self):
-        mc = rpc.Multicall(self)
+        mc = Multicall(self)
 
         for method in filter(lambda m: m.is_retriever() and m.is_available(self._rt_obj), self.methods):
             mc.add(method)
@@ -78,7 +77,7 @@ class Group(object):
         if method:
             methods = [m + '=' for m in methods]
 
-            mc = rpc.Multicall(self)
+            mc = Multicall(self)
 
             self.multicall_add(
                 mc, method,

--- a/lib/rtorrent/peer.py
+++ b/lib/rtorrent/peer.py
@@ -19,8 +19,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from .common import safe_repr
-from .rpc import Method
-import rpc
+from .rpc import Method, Multicall
 
 
 class Peer(object):
@@ -44,7 +43,7 @@ class Peer(object):
 
         @return: None
         """
-        mc = rpc.Multicall(self)
+        mc = Multicall(self)
 
         for method in filter(lambda fx: fx.is_retriever() and fx.is_available(self._rt_obj), methods):
             mc.add(method, self.rpc_id)

--- a/lib/rtorrent/tracker.py
+++ b/lib/rtorrent/tracker.py
@@ -19,8 +19,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from .common import safe_repr
-from .rpc import Method
-import rpc
+from .rpc import Method, Multicall
 
 
 class Tracker(object):
@@ -56,7 +55,7 @@ class Tracker(object):
 
         @return: None
         """
-        mc = rpc.Multicall(self)
+        mc = Multicall(self)
 
         for method in filter(lambda fx: fx.is_retriever() and fx.is_available(self._rt_obj), methods):
             mc.add(method, self.rpc_id)
@@ -73,7 +72,7 @@ class Tracker(object):
         @return: if successful, 0
         @rtype: int
         """
-        mc = rpc.Multicall(self)
+        mc = Multicall(self)
 
         self.multicall_add(mc, 'd.tracker.insert', self.index, tracker)
 


### PR DESCRIPTION
This PR changes the `import rpc` calls in lib/rtorrent to relative calls. It is required to run SickGear with `python3`