### PR TITLE
add some debug info to search.py

### DIFF
--- a/sickgear/search.py
+++ b/sickgear/search.py
@@ -771,6 +771,8 @@ def cache_torrent_file(
         with open(cache_file, 'rb') as fh:
             torrent_content = fh.read()
     except (BaseException, Exception):
+        logger.warning(f'parsing torrent content failed, skipping')
+        logger.debug(f'Torrent content: %s' % torrent_content)
         return
 
     try:


### PR DESCRIPTION
when parsing a torrent file fails the torrent is silently skipped, now providing some more information on why this torrent is skipped.

This might be usefull for some torrent providers that might allow search but give out status information about the account in the torrent file if something is to be done.