### PR TITLE
Fix stopping SickGear with non-root PID file

### DIFF
--- a/init-scripts/init.ubuntu
+++ b/init-scripts/init.ubuntu
@@ -101,7 +101,7 @@ start_sickgear() {
 
 stop_sickgear() {
     echo "Stopping $DESC"
-    start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+    start-stop-daemon --stop --pidfile $PID_FILE --exec $DAEMON --retry 15
 }
 
 case "$1" in


### PR DESCRIPTION
## Problem

`start-stop-daemon` refuses to stop SickGear when matching only against its non-root-owned PID file:

```text
start-stop-daemon: matching only on non-root pidfile /var/run/sickgear/sickgear.pid is insecure
```

This causes `service sickgear restart` to fail because the existing SickGear process remains running.

## Fix

Add `--exec $DAEMON` to the stop command so `start-stop-daemon` matches both the PID file and the expected executable.

```diff
-start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+start-stop-daemon --stop --pidfile $PID_FILE --exec $DAEMON --retry 15
```

## Testing

Tested with SickGear running as the non-root `sickgear` user.

Verified that:

* `service sickgear stop` successfully stops SickGear
* `service sickgear start` successfully starts SickGear
* `service sickgear restart` successfully stops and starts SickGear
